### PR TITLE
feat: 新增鼠标滚轮调整窗口大小功能

### DIFF
--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -49,6 +49,29 @@ export function useModel() {
     live2d.model?.scale.set(innerWidth / 612)
   }
 
+  async function handleMouseWheel(event: WheelEvent) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const appWindow = getCurrentWebviewWindow()
+
+    try {
+      const currentSize = (await appWindow.outerSize()).toLogical(window.devicePixelRatio)
+
+      const scaleFactor = event.deltaY > 0 ? 0.95 : 1.05
+
+      const newWidth = Math.round(currentSize.width * scaleFactor)
+      const newHeight = Math.round(currentSize.height * scaleFactor)
+
+      await appWindow.setSize(new LogicalSize(
+        Math.max(200, newWidth),
+        Math.max(200, newHeight),
+      ))
+    } catch (error) {
+      console.error('调整窗口大小失败:', error)
+    }
+  }
+
   function handleKeyDown(value: string[]) {
     const hasArrowKey = value.some(key => key.endsWith('Arrow'))
     const hasNonArrowKey = value.some(key => !key.endsWith('Arrow'))
@@ -94,5 +117,6 @@ export function useModel() {
     handleKeyDown,
     handleMouseMove,
     handleMouseDown,
+    handleMouseWheel,
   }
 }

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
-import { LogicalSize } from '@tauri-apps/api/window'
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 
@@ -10,7 +9,7 @@ import { useCatStore } from '@/stores/cat'
 
 const appWindow = getCurrentWebviewWindow()
 const { pressedMouses, mousePosition, pressedKeys } = useDevice()
-const { handleLoad, handleDestroy, handleResize, handleMouseDown, handleMouseMove, handleKeyDown } = useModel()
+const { handleLoad, handleDestroy, handleResize, handleMouseDown, handleMouseMove, handleKeyDown, handleMouseWheel } = useModel()
 const catStore = useCatStore()
 
 const resizing = ref(false)
@@ -30,27 +29,6 @@ useEventListener('resize', () => {
 
   handleDebounceResize()
 })
-
-async function handleMouseWheel(event: WheelEvent) {
-  event.preventDefault()
-  event.stopPropagation()
-
-  try {
-    const currentSize = (await appWindow.outerSize()).toLogical(window.devicePixelRatio)
-
-    const scaleFactor = event.deltaY > 0 ? 0.95 : 1.05
-
-    const newWidth = Math.round(currentSize.width * scaleFactor)
-    const newHeight = Math.round(currentSize.height * scaleFactor)
-
-    await appWindow.setSize(new LogicalSize(
-      Math.max(200, newWidth),
-      Math.max(200, newHeight),
-    ))
-  } catch (error) {
-    console.error('调整窗口大小失败:', error)
-  }
-}
 
 useEventListener('wheel', handleMouseWheel, { passive: false })
 


### PR DESCRIPTION
还有个更加丝滑的实现，不改变窗口大小，只改变内容大小，这样连重绘都不需要了。
然后只需要拖一个比较大的窗口大小，里面的内容随便改。
坏处是必须设置穿透，不然可能出现观测到的大小和实际大小不符的问题，不过感觉这个更符合直觉。