### PR TITLE
fix: cats will hide during hot updates

### DIFF
--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -2,12 +2,13 @@
 import { Menu } from '@tauri-apps/api/menu'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { useDebounceFn, useEventListener } from '@vueuse/core'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onBeforeMount, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { useDevice } from '@/composables/useDevice'
 import { useModel } from '@/composables/useModel'
 import { useSharedMenu } from '@/composables/useSharedMenu'
 import { useCatStore } from '@/stores/cat'
+import live2d from '@/utils/live2d.ts'
 
 const appWindow = getCurrentWebviewWindow()
 const { pressedMouses, mousePosition, pressedKeys } = useDevice()
@@ -16,9 +17,10 @@ const catStore = useCatStore()
 const { getSharedMenu } = useSharedMenu()
 
 const resizing = ref(false)
+const live2dContainer = ref<HTMLDivElement>()
 
-onMounted(handleLoad)
-
+onBeforeMount(handleLoad)
+onMounted(() => live2dContainer.value && live2d.mount(live2dContainer.value))
 onUnmounted(handleDestroy)
 
 const handleDebounceResize = useDebounceFn(async () => {
@@ -64,6 +66,7 @@ function resolveImageURL(key: string) {
 
 <template>
   <div
+    ref="live2dContainer"
     class="relative children:(absolute h-screen w-screen)"
     :class="[catStore.mirrorMode ? '-scale-x-100' : 'scale-x-100']"
     :style="{ opacity: catStore.opacity / 100 }"
@@ -71,8 +74,6 @@ function resolveImageURL(key: string) {
     @mousedown="handleWindowDrag"
   >
     <img :src="`/images/backgrounds/${catStore.mode}.png`">
-
-    <canvas id="live2dCanvas" />
 
     <img
       v-for="key in pressedKeys"

--- a/src/utils/live2d.ts
+++ b/src/utils/live2d.ts
@@ -9,11 +9,8 @@ class Live2d {
 
   constructor() { }
 
-  private mount() {
-    const view = document.getElementById('live2dCanvas') as HTMLCanvasElement
-
+  private create() {
     this.app = new Application({
-      view,
       resizeTo: window,
       backgroundAlpha: 0,
       autoDensity: true,
@@ -21,9 +18,16 @@ class Live2d {
     })
   }
 
+  public mount(anchor: HTMLElement) {
+    if (!this.app && import.meta.env.DEV) {
+      console.warn('Perform the mount operation after creating the PixiJS Application instance.')
+    }
+    this.app && anchor.appendChild(this.app.view)
+  }
+
   public async load(url: string) {
     if (!this.app) {
-      this.mount()
+      this.create()
     }
 
     const model = await Live2DModel.from(url)


### PR DESCRIPTION
当Vite进行热更新时，猫猫就会消失。

https://github.com/ayangweb/BongoCat/blob/9d1170063c3cdb068133e140a0e9cca97f565c72/src/utils/live2d.ts#L12-L22

原因是当PIXI.Application创建时，获取id为live2dCanvas的canvas元素并给PIXI.Application，此时canvas已经固定。当热更新时后，页面id为live2dCanvas的canvas元素和PIXI.Application保存的canvas元素不再是同一个对象。