### PR TITLE
chore: enable optimizations on release profile, migrate to rust 2024 …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 resolver = "2"
 members = [ "src-tauri" ]
 
+[profile.release]
+strip = true
+opt-level = 3
+codegen-units = 1
+panic = "abort"
+debug-assertions = false
+overflow-checks = false
+lto = true
+
 [workspace.dependencies]
 tauri = "2"
 serde = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "bongo-cat"
 version = "0.4.0"
 description = "A Tauri App"
 authors = [ "ayangweb" ]
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/plugins/window/Cargo.toml
+++ b/src-tauri/src/plugins/window/Cargo.toml
@@ -3,8 +3,8 @@ name = "tauri-plugin-custom-window"
 version = "0.1.0"
 authors = []
 description = ""
-edition = "2021"
-rust-version = "1.77.2"
+edition = "2024"
+rust-version = "1.85.0"
 links = "tauri-plugin-custom-window"
 
 [dependencies]


### PR DESCRIPTION
…edition

Those changes allow us to achieve both performance gains and size reduction.

Tested on x86_64-apple-darwin target, size: 18.5 MB -> 10.4 MB