### PR TITLE
chore: 启用ESLint作为VSCode格式化程序

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   // Disable the default formatter, use eslint instead
   "prettier.enable": false,
 
+  "eslint.format.enable": true,
+
   // Auto fix
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",


### PR DESCRIPTION
在格式化时可以采用ESLint作为默认格式化程序，避免在手动格式化时出现“配置默认格式化程序”弹窗。

![image](https://github.com/user-attachments/assets/57ce74f4-a61f-4fab-943e-f876ab803388)