### PR TITLE
feat: internationalize application to English

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       },
       {
         "label": "preference",
-        "title": "偏好设置",
+        "title": "Preferences",
         "url": "index.html/#/preference",
         "visible": false,
         "titleBarStyle": "Overlay",

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@ import { error } from '@tauri-apps/plugin-log'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { useEventListener } from '@vueuse/core'
 import { ConfigProvider } from 'ant-design-vue'
-import zhCN from 'ant-design-vue/es/locale/zh_CN'
+import enUS from 'ant-design-vue/es/locale/en_US'
 import { isString } from 'es-toolkit'
 import isURL from 'is-url'
 import { onMounted } from 'vue'
@@ -81,7 +81,7 @@ useEventListener('click', (event) => {
 </script>
 
 <template>
-  <ConfigProvider :locale="zhCN">
+  <ConfigProvider :locale="enUS">
     <RouterView v-if="isRestored" />
   </ConfigProvider>
 </template>

--- a/src/components/update-app/index.vue
+++ b/src/components/update-app/index.vue
@@ -51,7 +51,7 @@ useTauriListen<boolean>(LISTEN_KEY.UPDATE_APP, () => {
   message.loading({
     key: MESSAGE_KEY,
     duration: 0,
-    content: '正在检查更新...',
+    content: 'Checking for updates...',
   })
 })
 
@@ -91,7 +91,7 @@ async function checkUpdate(visibleMessage = false) {
 
       message.destroy(MESSAGE_KEY)
     } else if (visibleMessage) {
-      message.success({ key: MESSAGE_KEY, content: '当前已是最新版本🎉' })
+      message.success({ key: MESSAGE_KEY, content: 'Already the latest version 🎉' })
     }
   } catch (error) {
     if (!visibleMessage) return
@@ -135,15 +135,15 @@ async function handleOk() {
 <template>
   <Modal
     v-model:open="state.open"
-    cancel-text="稍后更新"
+    cancel-text="Update Later"
     centered
     :closable="false"
     :mask-closable="false"
-    title="发现新版本🥳"
+    title="New Version Found 🥳"
     @ok="handleOk"
   >
     <template #okText>
-      {{ state.downloading ? downloadProgress : "立即更新" }}
+      {{ state.downloading ? downloadProgress : "Update Now" }}
     </template>
 
     <Flex
@@ -152,7 +152,7 @@ async function handleOk() {
       vertical
     >
       <Flex align="center">
-        <span>更新版本：</span>
+        <span>Update Version: </span>
         <span>
           <span>{{ state.update?.currentVersion }} 👉 </span>
           <a
@@ -164,12 +164,12 @@ async function handleOk() {
       </Flex>
 
       <Flex align="center">
-        <span>更新时间：</span>
+        <span>Update Time: </span>
         <span>{{ state.update?.date }}</span>
       </Flex>
 
       <Flex vertical>
-        <span>更新日志：</span>
+        <span>Update Log: </span>
 
         <VueMarkdown
           class="update-note max-h-40 overflow-auto"

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -105,7 +105,7 @@ function resolveImagePath(key: string, side: 'left' | 'right' = 'left') {
       class="flex items-center justify-center bg-black"
     >
       <span class="text-center text-5xl text-white">
-        重绘中...
+        Redrawing...
       </span>
     </div>
   </div>

--- a/src/pages/preference/components/about/index.vue
+++ b/src/pages/preference/components/about/index.vue
@@ -36,7 +36,7 @@ async function copyInfo() {
 
   await writeText(JSON.stringify(info, null, 2))
 
-  message.success('复制成功')
+  message.success('Copied successfully')
 }
 
 function feedbackIssue() {
@@ -45,16 +45,16 @@ function feedbackIssue() {
 </script>
 
 <template>
-  <ProList title="关于软件">
+  <ProList title="About">
     <ProListItem
-      :description="`版本：v${appStore.version}`"
+      :description="`Version: v${appStore.version}`"
       :title="appStore.name"
     >
       <Button
         type="primary"
         @click="handleUpdate"
       >
-        检查更新
+        Check for Updates
       </Button>
 
       <template #icon>
@@ -68,20 +68,20 @@ function feedbackIssue() {
     </ProListItem>
 
     <ProListItem
-      description="复制软件信息并提供给 Bug Issue"
-      title="软件信息"
+      description="Copy software information and provide it to Bug Issue"
+      title="Software Information"
     >
       <Button @click="copyInfo">
-        复制
+        Copy
       </Button>
     </ProListItem>
 
-    <ProListItem title="开源地址">
+    <ProListItem title="Open Source Address">
       <Button
         danger
         @click="feedbackIssue"
       >
-        反馈问题
+        Feedback Issue
       </Button>
 
       <template #description>
@@ -93,10 +93,10 @@ function feedbackIssue() {
 
     <ProListItem
       :description="logDir"
-      title="软件日志"
+      title="Software Log"
     >
       <Button @click="openPath(logDir)">
-        查看日志
+        View Log
       </Button>
     </ProListItem>
   </ProList>

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -13,47 +13,47 @@ function opacityFormatter(value?: number) {
 </script>
 
 <template>
-  <ProList title="模型设置">
+  <ProList title="Model Settings">
     <ProListItem
-      description="启用后，模型将水平镜像翻转"
-      title="镜像模式"
+      description="When enabled, the model will be flipped horizontally."
+      title="Mirror Mode"
     >
       <Switch v-model:checked="catStore.mirrorMode" />
     </ProListItem>
 
     <ProListItem
-      description="启用后，每只手只显示最后按下的一个按键"
-      title="单键模式"
+      description="When enabled, only the last pressed key will be displayed for each hand."
+      title="Single Key Mode"
     >
       <Switch v-model:checked="catStore.singleMode" />
     </ProListItem>
 
     <ProListItem
-      description="启用后，鼠标将镜像跟随手部移动"
-      title="鼠标镜像"
+      description="When enabled, the mouse will mirror the movement of the hand."
+      title="Mouse Mirror"
     >
       <Switch v-model:checked="catStore.mouseMirror" />
     </ProListItem>
   </ProList>
 
-  <ProList title="窗口设置">
+  <ProList title="Window Settings">
     <ProListItem
-      description="启用后，窗口不影响对其他应用程序的操作"
-      title="窗口穿透"
+      description="When enabled, the window will not affect operations on other applications."
+      title="Window Penetration"
     >
       <Switch v-model:checked="catStore.penetrable" />
     </ProListItem>
 
     <ProListItem
-      description="启用后，窗口始终显示在其他应用程序上方"
-      title="窗口置顶"
+      description="When enabled, the window will always be displayed on top of other applications."
+      title="Always on Top"
     >
       <Switch v-model:checked="catStore.alwaysOnTop" />
     </ProListItem>
 
     <ProListItem
-      description="将鼠标移动到窗口边缘后，也可以拖动调整窗口尺寸"
-      title="窗口尺寸"
+      description="After moving the mouse to the edge of the window, you can also drag to adjust the window size."
+      title="Window Size"
     >
       <InputNumber
         v-model:value="catStore.scale"
@@ -67,7 +67,7 @@ function opacityFormatter(value?: number) {
     </ProListItem>
 
     <ProListItem
-      title="不透明度"
+      title="Opacity"
       vertical
     >
       <Slider

--- a/src/pages/preference/components/general/index.vue
+++ b/src/pages/preference/components/general/index.vue
@@ -27,14 +27,14 @@ watch(() => generalStore.autostart, async (value) => {
 <template>
   <MacosPermissions />
 
-  <ProList title="应用设置">
-    <ProListItem title="开机自启动">
+  <ProList title="Application Settings">
+    <ProListItem title="Startup on Boot">
       <Switch v-model:checked="generalStore.autostart" />
     </ProListItem>
   </ProList>
 
-  <ProList title="更新设置">
-    <ProListItem title="自动检查更新">
+  <ProList title="Update Settings">
+    <ProListItem title="Automatically Check for Updates">
       <Switch v-model:checked="generalStore.autoCheckUpdate" />
     </ProListItem>
   </ProList>

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -39,7 +39,7 @@ async function handleDelete(item: Model) {
   try {
     await remove(path, { recursive: true })
 
-    message.success('删除成功')
+    message.success('Deleted successfully')
   } catch (error) {
     message.error(String(error))
   } finally {
@@ -91,9 +91,9 @@ async function handleDelete(item: Model) {
 
           <template v-if="!item.isPreset">
             <Popconfirm
-              description="你确定要删除此模型吗？"
+              description="Are you sure you want to delete this model?"
               placement="topRight"
-              title="删除模型"
+              title="Delete Model"
               @confirm="handleDelete(item)"
             >
               <i

--- a/src/pages/preference/components/shortcut/index.vue
+++ b/src/pages/preference/components/shortcut/index.vue
@@ -34,35 +34,35 @@ useTauriKeyPress(alwaysOnTop, () => {
 </script>
 
 <template>
-  <ProList title="快捷键">
+  <ProList title="Shortcut Keys">
     <ProShortcut
       v-model="shortcutStore.visibleCat"
-      description="切换猫咪窗口的显示与隐藏"
-      title="打开猫咪"
+      description="Toggle the display of the cat window"
+      title="Open Cat"
     />
 
     <ProShortcut
       v-model="shortcutStore.visiblePreference"
-      description="切换偏好设置窗口的显示与隐藏"
-      title="打开偏好设置"
+      description="Toggle the display of the preference window"
+      title="Open Preferences"
     />
 
     <ProShortcut
       v-model="shortcutStore.mirrorMode"
-      description="切换猫咪的镜像模式"
-      title="镜像模式"
+      description="Toggle mirror mode for the cat"
+      title="Mirror Mode"
     />
 
     <ProShortcut
       v-model="shortcutStore.penetrable"
-      description="切换猫咪窗口是否可穿透"
-      title="窗口穿透"
+      description="Toggle whether the cat window is penetrable"
+      title="Window Penetration"
     />
 
     <ProShortcut
       v-model="shortcutStore.alwaysOnTop"
-      description="切换猫咪窗口是否置顶"
-      title="窗口置顶"
+      description="Toggle whether the cat window is always on top"
+      title="Always on Top"
     />
   </ProList>
 </template>

--- a/src/pages/preference/index.vue
+++ b/src/pages/preference/index.vue
@@ -23,27 +23,27 @@ onMounted(async () => {
 
 const menus = [
   {
-    label: '猫咪设置',
+    label: 'Cat Settings',
     icon: 'i-solar:cat-bold',
     component: Cat,
   },
   {
-    label: '通用设置',
+    label: 'General Settings',
     icon: 'i-solar:settings-minimalistic-bold',
     component: General,
   },
   {
-    label: '模型管理',
+    label: 'Model Management',
     icon: 'i-solar:magic-stick-3-bold',
     component: Model,
   },
   {
-    label: '快捷键',
+    label: 'Shortcut',
     icon: 'i-solar:keyboard-bold',
     component: Shortcut,
   },
   {
-    label: '关于',
+    label: 'About',
     icon: 'i-solar:info-circle-bold',
     component: About,
   },


### PR DESCRIPTION
Replaced all Chinese text with English equivalents throughout the Vue components and Tauri configuration.

- Updated Ant Design locale to enUS.
- Translated UI elements like titles, buttons, and descriptions.
- Changed window title in tauri.conf.json to 'Preferences'.