### PR TITLE
feat(tauri): add English & Vietnamese to Windows installer and enable language selector

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -4,8 +4,13 @@
     "windows": {
       "digestAlgorithm": "sha256",
       "nsis": {
-        "languages": ["SimpChinese"],
-        "installMode": "both"
+        "languages": [
+          "English",
+          "Vietnamese",
+          "SimpChinese"
+        ],
+        "installMode": "both",
+        "displayLanguageSelector": true
       }
     }
   }


### PR DESCRIPTION
- Add English and Vietnamese language support to the Windows installer.
- Enable language selector during installation.