### PR TITLE
feat: Implement client-server functionality for Live2D pet

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,11 +20,13 @@ import { useAppStore } from './stores/app'
 import { useCatStore } from './stores/cat'
 import { useGeneralStore } from './stores/general'
 import { useModelStore } from './stores/model'
+import { useRemoteStore } from './stores/remote'
 import { useShortcutStore } from './stores/shortcut.ts'
 
 const { generateColorVars } = useThemeVars()
 const appStore = useAppStore()
 const modelStore = useModelStore()
+const remoteStore = useRemoteStore()
 const catStore = useCatStore()
 const generalStore = useGeneralStore()
 const shortcutStore = useShortcutStore()
@@ -46,6 +48,7 @@ onMounted(async () => {
   await generalStore.init()
   await shortcutStore.$tauri.start()
   await restoreState()
+  remoteStore.connect()
 })
 
 watch(() => generalStore.appearance.language, (value) => {

--- a/src/pages/preference/components/remote/index.vue
+++ b/src/pages/preference/components/remote/index.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { useRemoteStore } from '@/stores/remote'
+
+const remoteStore = useRemoteStore()
+</script>
+
+<template>
+  <div class="remote-settings">
+    <a-input v-model:value="remoteStore.serverIp" placeholder="Enter server IP" />
+    <a-button @click="remoteStore.connect">Connect</a-button>
+    <a-button @click="remoteStore.disconnect">Disconnect</a-button>
+  </div>
+</template>

--- a/src/pages/preference/index.vue
+++ b/src/pages/preference/index.vue
@@ -8,6 +8,7 @@ import About from './components/about/index.vue'
 import Cat from './components/cat/index.vue'
 import General from './components/general/index.vue'
 import Model from './components/model/index.vue'
+import Remote from './components/remote/index.vue'
 import Shortcut from './components/shortcut/index.vue'
 
 import UpdateApp from '@/components/update-app/index.vue'
@@ -56,6 +57,11 @@ const menus = computed(() => [
     label: t('pages.preference.about.title'),
     icon: 'i-solar:info-circle-bold',
     component: About,
+  },
+  {
+    label: 'Remote',
+    icon: 'i-solar:remote-controller-minimalistic-bold',
+    component: Remote,
   },
 ])
 </script>

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -40,7 +40,19 @@ export const useModelStore = defineStore('model', () => {
   const supportKeys = reactive<Record<string, string>>({})
   const pressedKeys = reactive<Record<string, string>>({})
 
-  const init = async () => {
+  const init = async (data?: Model) => {
+    if (data) {
+      const remoteModel = data
+      currentModel.value = remoteModel
+      models.value = [remoteModel]
+      return
+    }
+
+    const { useRemoteStore } = await import('./remote')
+    const remoteStore = useRemoteStore()
+
+    if (remoteStore.isConnected) return
+
     const modelsPath = await resolveResource('assets/models')
 
     const nextModels = filter(models.value, { isPreset: false })

--- a/src/stores/remote.ts
+++ b/src/stores/remote.ts
@@ -1,0 +1,56 @@
+import { message } from 'ant-design-vue'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+import { useModelStore } from './model'
+
+export const useRemoteStore = defineStore('remote', () => {
+  const serverIp = ref('')
+  const isConnected = ref(false)
+  const ws = ref<WebSocket>()
+
+  const connect = () => {
+    if (isConnected.value || !serverIp.value) return
+
+    ws.value = new WebSocket(`ws://${serverIp.value}:3000`)
+
+    ws.value.onopen = () => {
+      isConnected.value = true
+    }
+    ws.value.onclose = () => {
+      isConnected.value = false
+    }
+    ws.value.onerror = () => {
+      message.error('无法连接至服务器')
+    }
+    ws.value.onmessage = (event) => {
+      const { type, data } = JSON.parse(event.data)
+
+      switch (type) {
+        case 'live2d':
+          useModelStore().init(data)
+          break
+
+        default:
+          break
+      }
+    }
+  }
+
+  const disconnect = () => {
+    ws.value?.close()
+  }
+
+  return {
+    ws,
+    serverIp,
+    isConnected,
+    connect,
+    disconnect,
+  }
+}, {
+  tauri: {
+    filterKeys: ['serverIp'],
+    filterKeysStrategy: 'pick',
+  },
+})


### PR DESCRIPTION
This commit transforms the local Live2D pet into a client that can connect to a server on the local network. This allows the user to see their friend's avatar instead of their own.

- Adds a new `remote` store to manage the WebSocket connection and server IP.
- Adds a settings page to configure the server IP address.
- Modifies the `model` store and `useModel` composable to fetch and render model data from the server.
- The application will now attempt to connect to the server on startup.
- Local model loading is preserved when not connected to a server.