### PR TITLE
feat(opacity): implement radial gradient distance opacity

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "../package.json",
   "identifier": "com.ayangweb.BongoCat",
   "build": {
-    "beforeDevCommand": "pnpm dev",
+    "beforeDevCommand": "npx pnpm dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "pnpm build",
+    "beforeBuildCommand": "npx pnpm build",
     "frontendDist": "../dist"
   },
   "app": {

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -81,6 +81,28 @@ export function useDevice() {
       if (!catStore.window.passThrough) {
         appWindow.setIgnoreCursorEvents(isInWindow)
       }
+    } else if (catStore.window.distanceOpacity) {
+      const appWindow = getCurrentWebviewWindow()
+      const position = await appWindow.outerPosition()
+
+      const scale = window.devicePixelRatio
+      const x = (cursorPoint.x - position.x) / scale
+      const y = (cursorPoint.y - position.y) / scale
+
+      const threshold = catStore.window.distanceThreshold
+      const minOpacity = catStore.window.minOpacity / 100
+      const gradient = catStore.window.distanceGradient || 100
+
+      const style = document.body.style
+      const maskStyle = `radial-gradient(circle ${threshold}px at ${x}px ${y}px, rgba(0,0,0,${minOpacity}) 0%, rgba(0,0,0,1) ${gradient}%)`
+
+      style.setProperty('-webkit-mask-image', maskStyle)
+      style.setProperty('mask-image', maskStyle)
+      style.removeProperty('opacity')
+    } else {
+      document.body.style.removeProperty('opacity')
+      document.body.style.removeProperty('-webkit-mask-image')
+      document.body.style.removeProperty('mask-image')
     }
   }
 

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -21,7 +21,11 @@
           "windowRadius": "Window Radius",
           "opacity": "Opacity",
           "autoReleaseDelay": "Auto Release Delay",
-          "hideOnHover": "Hide on Hover"
+          "hideOnHover": "Hide on Hover",
+          "distanceOpacity": "Distance Opacity",
+          "distanceThreshold": "Sense Distance",
+          "minOpacity": "Min Opacity",
+          "distanceGradient": "Gradient Coefficient"
         },
         "hints": {
           "mirrorMode": "When enabled, the model will be horizontally flipped.",
@@ -31,7 +35,8 @@
           "alwaysOnTop": "When enabled, the window will always stay above other applications.",
           "windowSize": "Move the mouse to the edge of the window or hold Shift and right-drag to resize.",
           "autoReleaseDelay": "Due to Windows not capturing the release events of certain system-level keys, they will be automatically treated as released after a timeout.",
-          "hideOnHover": "When enabled, the window will hide when the mouse hovers over it."
+          "hideOnHover": "When enabled, the window will hide when the mouse hovers over it.",
+          "distanceOpacity": "When enabled, the cat's opacity changes with mouse distance."
         }
       },
       "general": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -21,7 +21,11 @@
           "windowRadius": "Độ bo tròn cửa sổ",
           "opacity": "Độ mờ",
           "autoReleaseDelay": "Độ trễ tự động nhả phím",
-          "hideOnHover": "Ẩn khi di chuột"
+          "hideOnHover": "Ẩn khi di chuột",
+          "distanceOpacity": "Độ mờ theo khoảng cách",
+          "distanceThreshold": "Khoảng cách cảm ứng",
+          "minOpacity": "Độ mờ tối thiểu",
+          "distanceGradient": "Hệ số gradient"
         },
         "hints": {
           "mirrorMode": "Bật để lật ngang mô hình.",
@@ -31,7 +35,8 @@
           "alwaysOnTop": "Bật để cửa sổ luôn nằm trên ứng dụng khác.",
           "windowSize": "Di chuyển chuột đến mép cửa sổ hoặc giữ Shift và kéo chuột phải để thay đổi kích thước.",
           "autoReleaseDelay": "Do Windows không bắt được sự kiện nhả của một số phím hệ thống, các phím đó sẽ được tự động xem như đã nhả sau khi hết thời gian chờ.",
-          "hideOnHover": "Khi bật, cửa sổ sẽ ẩn khi chuột di chuyển vào."
+          "hideOnHover": "Khi bật, cửa sổ sẽ ẩn khi chuột di chuyển vào.",
+          "distanceOpacity": "Khi bật, độ mờ của mèo sẽ thay đổi theo khoảng cách chuột."
         }
       },
       "general": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -21,7 +21,11 @@
           "windowRadius": "窗口圆角",
           "opacity": "不透明度",
           "autoReleaseDelay": "按键自动释放延迟",
-          "hideOnHover": "鼠标移入隐藏"
+          "hideOnHover": "鼠标移入隐藏",
+          "distanceOpacity": "距离感应透明度",
+          "distanceThreshold": "感应距离",
+          "minOpacity": "最低透明度",
+          "distanceGradient": "渐变系数"
         },
         "hints": {
           "mirrorMode": "启用后，模型将水平镜像翻转。",
@@ -31,7 +35,8 @@
           "alwaysOnTop": "启用后，窗口始终显示在其他应用程序上方。",
           "windowSize": "将鼠标移至窗口边缘，或按住 Shift 并右键拖动，也可以调整窗口大小。",
           "autoReleaseDelay": "由于 Windows 下部分系统级按键无法捕获释放事件，超时后将自动视为已释放。",
-          "hideOnHover": "启用后，鼠标悬停在窗口上时，窗口会隐藏。"
+          "hideOnHover": "启用后，鼠标悬停在窗口上时，窗口会隐藏。",
+          "distanceOpacity": "启用后，小猫透明度会随鼠标距离变化。"
         }
       },
       "general": {

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -64,8 +64,58 @@ const catStore = useCatStore()
       :description="$t('pages.preference.cat.hints.hideOnHover')"
       :title="$t('pages.preference.cat.labels.hideOnHover')"
     >
-      <Switch v-model:checked="catStore.window.hideOnHover" />
+      <Switch
+        v-model:checked="catStore.window.hideOnHover"
+        :disabled="catStore.window.distanceOpacity"
+      />
     </ProListItem>
+
+    <ProListItem
+      :description="$t('pages.preference.cat.hints.distanceOpacity')"
+      :title="$t('pages.preference.cat.labels.distanceOpacity')"
+    >
+      <Switch
+        v-model:checked="catStore.window.distanceOpacity"
+        :disabled="catStore.window.hideOnHover"
+      />
+    </ProListItem>
+
+    <template v-if="catStore.window.distanceOpacity">
+      <ProListItem :title="$t('pages.preference.cat.labels.distanceThreshold')">
+        <InputNumber
+          v-model:value="catStore.window.distanceThreshold"
+          addon-after="px"
+          class="w-28"
+          :min="0"
+        />
+      </ProListItem>
+
+      <ProListItem
+        :title="$t('pages.preference.cat.labels.minOpacity')"
+        vertical
+      >
+        <Slider
+          v-model:value="catStore.window.minOpacity"
+          class="m-[0]!"
+          :max="100"
+          :min="0"
+          :tip-formatter="(value) => `${value}%`"
+        />
+      </ProListItem>
+
+      <ProListItem
+        :title="$t('pages.preference.cat.labels.distanceGradient')"
+        vertical
+      >
+        <Slider
+          v-model:value="catStore.window.distanceGradient"
+          class="m-[0]!"
+          :max="100"
+          :min="0"
+          :tip-formatter="(value) => `${value}%`"
+        />
+      </ProListItem>
+    </template>
 
     <ProListItem
       :description="$t('pages.preference.cat.hints.windowSize')"

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -16,6 +16,10 @@ export interface CatStore {
     opacity: number
     radius: number
     hideOnHover: boolean
+    distanceOpacity: boolean
+    distanceThreshold: number
+    minOpacity: number
+    distanceGradient: number
   }
 }
 
@@ -61,6 +65,10 @@ export const useCatStore = defineStore('cat', () => {
     opacity: 100,
     radius: 0,
     hideOnHover: false,
+    distanceOpacity: false,
+    distanceThreshold: 200,
+    minOpacity: 40,
+    distanceGradient: 100,
   })
 
   const init = () => {


### PR DESCRIPTION
- Add distance opacity state to CatStore (threshold, min opacity, gradient).
- Implement radial gradient mask logic in useDevice.ts for mouse interaction.
- Update useDevice.ts to respect global opacity with gradient mask.
- Add UI controls in preference page for distance opacity settings.
- Ensure mutual exclusivity between hideOnHover and distanceOpacity.
- Update localization files (en-US, zh-CN, vi-VN).
- Update tauri.conf.json build command to use npx pnpm.