### PR TITLE
feat: add statistics tracking for keyboard and mouse usage

### DIFF
--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { cursorPosition } from '@tauri-apps/api/window'
+import { ref } from 'vue'
 
 import { INVOKE_KEY, LISTEN_KEY } from '../constants'
 
@@ -9,8 +10,11 @@ import { useTauriListen } from './useTauriListen'
 
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
+import { useStatisticsStore } from '@/stores/statistics'
 import { inBetween } from '@/utils/is'
 import { isWindows } from '@/utils/platform'
+
+const isHovering = ref(false)
 
 interface MouseButtonEvent {
   kind: 'MousePress' | 'MouseRelease'
@@ -38,6 +42,7 @@ export function useDevice() {
   const modelStore = useModelStore()
   const releaseTimers = new Map<string, NodeJS.Timeout>()
   const catStore = useCatStore()
+  const statisticsStore = useStatisticsStore()
   const { handlePress, handleRelease, handleMouseChange, handleMouseMove } = useModel()
 
   const startListening = () => {
@@ -68,14 +73,16 @@ export function useDevice() {
 
     handleMouseMove(cursorPoint)
 
+    const appWindow = getCurrentWebviewWindow()
+    const position = await appWindow.outerPosition()
+    const { width, height } = await appWindow.innerSize()
+
+    const isInWindow = inBetween(cursorPoint.x, position.x, position.x + width)
+      && inBetween(cursorPoint.y, position.y, position.y + height)
+
+    isHovering.value = isInWindow
+
     if (catStore.window.hideOnHover) {
-      const appWindow = getCurrentWebviewWindow()
-      const position = await appWindow.outerPosition()
-      const { width, height } = await appWindow.innerSize()
-
-      const isInWindow = inBetween(cursorPoint.x, position.x, position.x + width)
-        && inBetween(cursorPoint.y, position.y, position.y + height)
-
       document.body.style.setProperty('opacity', isInWindow ? '0' : 'unset')
 
       if (!catStore.window.passThrough) {
@@ -108,6 +115,10 @@ export function useDevice() {
 
       if (!nextValue) return
 
+      if (kind === 'KeyboardPress') {
+        statisticsStore.recordKeyPress(nextValue)
+      }
+
       if (nextValue === 'CapsLock') {
         return handleAutoRelease(nextValue)
       }
@@ -127,6 +138,7 @@ export function useDevice() {
 
     switch (kind) {
       case 'MousePress':
+        statisticsStore.recordMouseClick(value)
         return handleMouseChange(value)
       case 'MouseRelease':
         return handleMouseChange(value, false)
@@ -137,5 +149,6 @@ export function useDevice() {
 
   return {
     startListening,
+    isHovering,
   }
 }

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -3,18 +3,15 @@ import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { cursorPosition } from '@tauri-apps/api/window'
 import { ref } from 'vue'
 
-import { INVOKE_KEY, LISTEN_KEY } from '../constants'
-
 import { useModel } from './useModel'
 import { useTauriListen } from './useTauriListen'
 
+import { INVOKE_KEY, LISTEN_KEY } from '@/constants'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { useStatisticsStore } from '@/stores/statistics'
 import { inBetween } from '@/utils/is'
 import { isWindows } from '@/utils/platform'
-
-const isHovering = ref(false)
 
 interface MouseButtonEvent {
   kind: 'MousePress' | 'MouseRelease'
@@ -39,6 +36,7 @@ interface KeyboardEvent {
 type DeviceEvent = MouseButtonEvent | MouseMoveEvent | KeyboardEvent
 
 export function useDevice() {
+  const isHovering = ref(false)
   const modelStore = useModelStore()
   const releaseTimers = new Map<string, NodeJS.Timeout>()
   const catStore = useCatStore()

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -21,7 +21,11 @@
           "windowRadius": "Window Radius",
           "opacity": "Opacity",
           "autoReleaseDelay": "Auto Release Delay",
-          "hideOnHover": "Hide on Hover"
+          "hideOnHover": "Hide on Hover",
+          "statisticsSettings": "Statistics Settings",
+          "enableStatistics": "Enable Statistics",
+          "mouseClickStatistics": "Track Mouse Clicks",
+          "resetStatistics": "Reset Statistics"
         },
         "hints": {
           "mirrorMode": "When enabled, the model will be mirrored horizontally.",
@@ -31,7 +35,15 @@
           "alwaysOnTop": "When enabled, the window stays above all other windows.",
           "windowSize": "Move mouse to window edge, or hold Shift and right-drag to resize.",
           "autoReleaseDelay": "On Windows, some system keys cannot capture release events and will auto-release after timeout.",
-          "hideOnHover": "When enabled, the window hides when mouse hovers over it."
+          "hideOnHover": "When enabled, the window hides when mouse hovers over it.",
+          "enableStatistics": "When enabled, keyboard and mouse usage data will be tracked.",
+          "mouseClickStatistics": "When enabled, mouse clicks will be counted.",
+          "resetStatisticsConfirm": "Are you sure you want to reset all statistics?"
+        },
+        "buttons": {
+          "reset": "Reset",
+          "cancel": "Cancel",
+          "confirm": "Confirm"
         }
       },
       "general": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -21,7 +21,11 @@
           "windowRadius": "Raio da Janela",
           "opacity": "Opacidade",
           "autoReleaseDelay": "Atraso de Liberação Automática",
-          "hideOnHover": "Ocultar ao Passar o Mouse"
+          "hideOnHover": "Ocultar ao Passar o Mouse",
+          "statisticsSettings": "Configurações de Estatísticas",
+          "enableStatistics": "Ativar Estatísticas",
+          "mouseClickStatistics": "Rastrear Cliques do Mouse",
+          "resetStatistics": "Redefinir Estatísticas"
         },
         "hints": {
           "mirrorMode": "Quando ativado, o modelo será invertido horizontalmente.",
@@ -31,7 +35,15 @@
           "alwaysOnTop": "Quando ativado, a janela sempre ficará acima de outros aplicativos.",
           "windowSize": "Mova o mouse para a borda da janela ou segure Shift e arraste com o botão direito para redimensionar.",
           "autoReleaseDelay": "Devido ao Windows não capturar eventos de liberação de certas teclas de nível do sistema, elas serão automaticamente tratadas como liberadas após um tempo limite.",
-          "hideOnHover": "Quando ativado, a janela será ocultada quando o mouse passar sobre ela."
+          "hideOnHover": "Quando ativado, a janela será ocultada quando o mouse passar sobre ela.",
+          "enableStatistics": "Quando ativado, os dados de uso do teclado e mouse serão rastreados.",
+          "mouseClickStatistics": "Quando ativado, os cliques do mouse serão contados.",
+          "resetStatisticsConfirm": "Tem certeza de que deseja redefinir todas as estatísticas?"
+        },
+        "buttons": {
+          "reset": "Redefinir",
+          "cancel": "Cancelar",
+          "confirm": "Confirmar"
         }
       },
       "general": {

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -21,7 +21,11 @@
           "windowRadius": "Độ bo tròn cửa sổ",
           "opacity": "Độ mờ",
           "autoReleaseDelay": "Độ trễ tự động nhả phím",
-          "hideOnHover": "Ẩn khi di chuột"
+          "hideOnHover": "Ẩn khi di chuột",
+          "statisticsSettings": "Cài đặt Thống kê",
+          "enableStatistics": "Bật Thống kê",
+          "mouseClickStatistics": "Thống kê Click chuột",
+          "resetStatistics": "Đặt lại Thống kê"
         },
         "hints": {
           "mirrorMode": "Bật để lật ngang mô hình.",
@@ -31,7 +35,15 @@
           "alwaysOnTop": "Bật để cửa sổ luôn nằm trên ứng dụng khác.",
           "windowSize": "Di chuyển chuột đến mép cửa sổ hoặc giữ Shift và kéo chuột phải để thay đổi kích thước.",
           "autoReleaseDelay": "Do Windows không bắt được sự kiện nhả của một số phím hệ thống, các phím đó sẽ được tự động xem như đã nhả sau khi hết thời gian chờ.",
-          "hideOnHover": "Khi bật, cửa sổ sẽ ẩn khi chuột di chuyển vào."
+          "hideOnHover": "Khi bật, cửa sổ sẽ ẩn khi chuột di chuyển vào.",
+          "enableStatistics": "Khi bật, dữ liệu sử dụng bàn phím và chuột sẽ được thống kê.",
+          "mouseClickStatistics": "Khi bật, số lần click chuột sẽ được thống kê.",
+          "resetStatisticsConfirm": "Bạn có chắc muốn đặt lại tất cả thống kê không?"
+        },
+        "buttons": {
+          "reset": "Đặt lại",
+          "cancel": "Hủy",
+          "confirm": "Xác nhận"
         }
       },
       "general": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -21,7 +21,11 @@
           "windowRadius": "窗口圆角",
           "opacity": "不透明度",
           "autoReleaseDelay": "按键自动释放延迟",
-          "hideOnHover": "鼠标移入隐藏"
+          "hideOnHover": "鼠标移入隐藏",
+          "statisticsSettings": "统计设置",
+          "enableStatistics": "启用统计",
+          "mouseClickStatistics": "统计鼠标点击",
+          "resetStatistics": "重置统计"
         },
         "hints": {
           "mirrorMode": "启用后，模型将水平镜像翻转。",
@@ -31,7 +35,15 @@
           "alwaysOnTop": "启用后，窗口始终显示在其他应用程序上方。",
           "windowSize": "将鼠标移至窗口边缘，或按住 Shift 并右键拖动，也可以调整窗口大小。",
           "autoReleaseDelay": "由于 Windows 下部分系统级按键无法捕获释放事件，超时后将自动视为已释放。",
-          "hideOnHover": "启用后，鼠标悬停在窗口上时，窗口会隐藏。"
+          "hideOnHover": "启用后，鼠标悬停在窗口上时，窗口会隐藏。",
+          "enableStatistics": "启用后，将统计键盘和鼠标使用数据。",
+          "mouseClickStatistics": "启用后，将统计鼠标点击次数。",
+          "resetStatisticsConfirm": "确定要重置所有统计数据吗？"
+        },
+        "buttons": {
+          "reset": "重置",
+          "cancel": "取消",
+          "confirm": "确定"
         }
       },
       "general": {

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -8,7 +8,7 @@ import { exists, readDir } from '@tauri-apps/plugin-fs'
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { round } from 'es-toolkit'
 import { nth } from 'es-toolkit/compat'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { useDevice } from '@/composables/useDevice'
 import { useGamepad } from '@/composables/useGamepad'
@@ -18,11 +18,13 @@ import { hideWindow, setAlwaysOnTop, setTaskbarVisibility, showWindow } from '@/
 import { useCatStore } from '@/stores/cat'
 import { useGeneralStore } from '@/stores/general.ts'
 import { useModelStore } from '@/stores/model'
+import { useStatisticsStore } from '@/stores/statistics'
 import { isImage } from '@/utils/is'
 import { join } from '@/utils/path'
 import { clearObject } from '@/utils/shared'
 
-const { startListening } = useDevice()
+const { startListening, isHovering } = useDevice()
+const statisticsStore = useStatisticsStore()
 const appWindow = getCurrentWebviewWindow()
 const { modelSize, handleLoad, handleDestroy, handleResize, handleKeyChange } = useModel()
 const catStore = useCatStore()
@@ -141,6 +143,10 @@ function handleMouseMove(event: MouseEvent) {
 
   catStore.window.scale = round(nextScale)
 }
+
+const totalCount = computed(() => {
+  return statisticsStore.keyboard.total + statisticsStore.mouse.total
+})
 </script>
 
 <template>
@@ -176,6 +182,15 @@ function handleMouseMove(event: MouseEvent) {
     >
       <span class="text-center text-10vw text-white">
         {{ $t('pages.main.hints.redrawing') }}
+      </span>
+    </div>
+
+    <div
+      v-show="isHovering && statisticsStore.settings.enabled"
+      class="pointer-events-none flex items-end justify-center pb-[5%]"
+    >
+      <span class="rounded-full bg-black/60 px-10px py-6px text-16px text-white">
+        {{ totalCount }}
       </span>
     </div>
   </div>

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
-import { InputNumber, Slider, Switch } from 'ant-design-vue'
+import { Button, InputNumber, Popconfirm, Slider, Switch } from 'ant-design-vue'
 
 import ProList from '@/components/pro-list/index.vue'
 import ProListItem from '@/components/pro-list-item/index.vue'
 import { useCatStore } from '@/stores/cat'
+import { useStatisticsStore } from '@/stores/statistics'
 import { isWindows } from '@/utils/platform'
 
 const catStore = useCatStore()
+const statisticsStore = useStatisticsStore()
+
+function handleReset() {
+  statisticsStore.reset()
+}
 </script>
 
 <template>
@@ -99,6 +105,35 @@ const catStore = useCatStore()
         :min="10"
         :tip-formatter="(value) => `${value}%`"
       />
+    </ProListItem>
+  </ProList>
+
+  <ProList :title="$t('pages.preference.cat.labels.statisticsSettings')">
+    <ProListItem
+      :description="$t('pages.preference.cat.hints.enableStatistics')"
+      :title="$t('pages.preference.cat.labels.enableStatistics')"
+    >
+      <Switch v-model:checked="statisticsStore.settings.enabled" />
+    </ProListItem>
+
+    <ProListItem
+      :description="$t('pages.preference.cat.hints.mouseClickStatistics')"
+      :title="$t('pages.preference.cat.labels.mouseClickStatistics')"
+    >
+      <Switch v-model:checked="statisticsStore.settings.mouseClickEnabled" />
+    </ProListItem>
+
+    <ProListItem :title="$t('pages.preference.cat.labels.resetStatistics')">
+      <Popconfirm
+        :cancel-text="$t('pages.preference.cat.buttons.cancel')"
+        :ok-text="$t('pages.preference.cat.buttons.confirm')"
+        :title="$t('pages.preference.cat.hints.resetStatisticsConfirm')"
+        @confirm="handleReset"
+      >
+        <Button danger>
+          {{ $t('pages.preference.cat.buttons.reset') }}
+        </Button>
+      </Popconfirm>
     </ProListItem>
   </ProList>
 </template>

--- a/src/stores/statistics.ts
+++ b/src/stores/statistics.ts
@@ -1,0 +1,72 @@
+import { defineStore } from 'pinia'
+import { reactive } from 'vue'
+
+export interface StatisticsStore {
+  keyboard: {
+    total: number
+    keys: Record<string, number>
+  }
+  mouse: {
+    total: number
+    left: number
+    right: number
+  }
+  settings: {
+    enabled: boolean
+    mouseClickEnabled: boolean
+  }
+}
+
+export const useStatisticsStore = defineStore('statistics', () => {
+  const keyboard = reactive<StatisticsStore['keyboard']>({
+    total: 0,
+    keys: {},
+  })
+
+  const mouse = reactive<StatisticsStore['mouse']>({
+    total: 0,
+    left: 0,
+    right: 0,
+  })
+
+  const settings = reactive<StatisticsStore['settings']>({
+    enabled: true,
+    mouseClickEnabled: true,
+  })
+
+  const recordKeyPress = (key: string) => {
+    if (!settings.enabled) return
+    keyboard.total++
+    keyboard.keys[key] = (keyboard.keys[key] || 0) + 1
+  }
+
+  const recordMouseClick = (button: string) => {
+    if (!settings.enabled || !settings.mouseClickEnabled) return
+    mouse.total++
+    if (button === 'Left') mouse.left++
+    else if (button === 'Right') mouse.right++
+  }
+
+  const reset = () => {
+    keyboard.total = 0
+    keyboard.keys = {}
+    mouse.total = 0
+    mouse.left = 0
+    mouse.right = 0
+  }
+
+  return {
+    keyboard,
+    mouse,
+    settings,
+    // actions
+    recordKeyPress,
+    recordMouseClick,
+    reset,
+  }
+}, {
+  tauri: {
+    autoStart: true,
+    saveOnChange: true,
+  },
+})

--- a/src/stores/statistics.ts
+++ b/src/stores/statistics.ts
@@ -42,9 +42,13 @@ export const useStatisticsStore = defineStore('statistics', () => {
 
   const recordMouseClick = (button: string) => {
     if (!settings.enabled || !settings.mouseClickEnabled) return
-    mouse.total++
-    if (button === 'Left') mouse.left++
-    else if (button === 'Right') mouse.right++
+    if (button === 'Left') {
+      mouse.left++
+      mouse.total++
+    } else if (button === 'Right') {
+      mouse.right++
+      mouse.total++
+    }
   }
 
   const reset = () => {
@@ -68,5 +72,6 @@ export const useStatisticsStore = defineStore('statistics', () => {
   tauri: {
     autoStart: true,
     saveOnChange: true,
+    filterKeys: ['settings'],
   },
 })


### PR DESCRIPTION
Fix #110 

Introduces a new Pinia store to track keyboard and mouse usage statistics, including per-key and per-button counts. Adds UI controls and localization for enabling/disabling statistics, mouse click tracking, and resetting statistics. Displays total input count overlay on main window when hovering and statistics are enabled.