### PR TITLE
fix: throttle mouse movement to resolve lag on high polling rate devices

### DIFF
--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { cursorPosition } from '@tauri-apps/api/window'
+import { useThrottleFn } from '@vueuse/core'
 
 import { INVOKE_KEY, LISTEN_KEY } from '../constants'
 
@@ -84,6 +85,9 @@ export function useDevice() {
     }
   }
 
+  // Throttle mouse movement to ~60fps (16ms interval) to prevent lag with high polling rate mice
+  const throttledCursorMove = useThrottleFn(handleCursorMove, 16)
+
   const handleAutoRelease = (key: string, delay = 100) => {
     handlePress(key)
 
@@ -131,7 +135,7 @@ export function useDevice() {
       case 'MouseRelease':
         return handleMouseChange(value, false)
       case 'MouseMove':
-        return handleCursorMove()
+        return throttledCursorMove()
     }
   })
 


### PR DESCRIPTION
## Description
Resolves an issue where mouse movement causes significant lag when using high polling rate devices (e.g., Logitech Pro X Wireless), while standard devices (like laptop trackpads) work smoothly.

## Problem
The application was processing every mouse move event immediately. High polling rate mice send updates much faster than the render loop can handle (often >1000Hz vs 60Hz), causing the event queue to flood and the UI to freeze or lag.

## Solution
Implemented throttling on the [MouseMove](cci:2://file:///c:/Project/BongoCat/src/composables/useDevice.ts:25:0-28:1) event handler using `useThrottleFn` (from `@vueuse/core`). The handler is now limited to execute at most once every 16ms (~60fps), ensuring smooth performance regardless of the input device's polling rate.