### PR TITLE
fix: reduce mousemove jitter for high polling rate mice

### DIFF
--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core'
+import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
-import { cursorPosition } from '@tauri-apps/api/window'
 
 import { INVOKE_KEY, LISTEN_KEY } from '../constants'
 
@@ -33,12 +33,17 @@ interface KeyboardEvent {
 }
 
 type DeviceEvent = MouseButtonEvent | MouseMoveEvent | KeyboardEvent
+const MOUSE_MOVE_FRAME_MS = 16
 
 export function useDevice() {
+  const appWindow = getCurrentWebviewWindow()
   const modelStore = useModelStore()
-  const releaseTimers = new Map<string, NodeJS.Timeout>()
+  const releaseTimers = new Map<string, ReturnType<typeof setTimeout>>()
   const catStore = useCatStore()
   const { handlePress, handleRelease, handleMouseChange, handleMouseMove } = useModel()
+  let latestCursorPoint: PhysicalPosition | undefined
+  let lastMouseMoveAt = 0
+  let mouseMoveTimer: ReturnType<typeof setTimeout> | undefined
 
   const startListening = () => {
     invoke(INVOKE_KEY.START_DEVICE_LISTENING)
@@ -63,15 +68,12 @@ export function useDevice() {
     return nextKey
   }
 
-  const handleCursorMove = async () => {
-    const cursorPoint = await cursorPosition()
-
-    handleMouseMove(cursorPoint)
-
+  const updateHideOnHover = async (cursorPoint: PhysicalPosition) => {
     if (catStore.window.hideOnHover) {
-      const appWindow = getCurrentWebviewWindow()
-      const position = await appWindow.outerPosition()
-      const { width, height } = await appWindow.innerSize()
+      const [position, { width, height }] = await Promise.all([
+        appWindow.outerPosition(),
+        appWindow.innerSize(),
+      ])
 
       const isInWindow = inBetween(cursorPoint.x, position.x, position.x + width)
         && inBetween(cursorPoint.y, position.y, position.y + height)
@@ -82,6 +84,34 @@ export function useDevice() {
         appWindow.setIgnoreCursorEvents(isInWindow)
       }
     }
+  }
+
+  const scheduleMouseMove = () => {
+    if (mouseMoveTimer) return
+
+    const delay = Math.max(0, MOUSE_MOVE_FRAME_MS - (performance.now() - lastMouseMoveAt))
+
+    mouseMoveTimer = setTimeout(() => {
+      mouseMoveTimer = void 0
+      void flushMouseMove()
+    }, delay)
+  }
+
+  const flushMouseMove = () => {
+    if (!latestCursorPoint) return
+
+    const cursorPoint = latestCursorPoint
+
+    lastMouseMoveAt = performance.now()
+    latestCursorPoint = void 0
+
+    void handleMouseMove(cursorPoint)
+    void updateHideOnHover(cursorPoint)
+  }
+
+  const handleCursorMove = (cursorPoint: CursorPoint) => {
+    latestCursorPoint = new PhysicalPosition(cursorPoint.x, cursorPoint.y)
+    scheduleMouseMove()
   }
 
   const handleAutoRelease = (key: string, delay = 100) => {
@@ -131,7 +161,7 @@ export function useDevice() {
       case 'MouseRelease':
         return handleMouseChange(value, false)
       case 'MouseMove':
-        return handleCursorMove()
+        return handleCursorMove(value)
     }
   })
 

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -43,6 +43,7 @@ export function useDevice() {
   const { handlePress, handleRelease, handleMouseChange, handleMouseMove } = useModel()
   let latestCursorPoint: PhysicalPosition | undefined
   let lastMouseMoveAt = 0
+  let mouseMoveVersion = 0
   let mouseMoveTimer: ReturnType<typeof setTimeout> | undefined
 
   const startListening = () => {
@@ -67,6 +68,8 @@ export function useDevice() {
 
     return nextKey
   }
+
+  const isLatestMouseMove = (version: number) => version === mouseMoveVersion
 
   const updateHideOnHover = async (cursorPoint: PhysicalPosition) => {
     if (catStore.window.hideOnHover) {
@@ -101,16 +104,22 @@ export function useDevice() {
     if (!latestCursorPoint) return
 
     const cursorPoint = latestCursorPoint
+    const version = mouseMoveVersion
 
     lastMouseMoveAt = performance.now()
     latestCursorPoint = void 0
 
-    void handleMouseMove(cursorPoint)
+    void handleMouseMove(cursorPoint, { isLatest: () => isLatestMouseMove(version) })
     void updateHideOnHover(cursorPoint)
+
+    if (version !== mouseMoveVersion) {
+      scheduleMouseMove()
+    }
   }
 
   const handleCursorMove = (cursorPoint: CursorPoint) => {
     latestCursorPoint = new PhysicalPosition(cursorPoint.x, cursorPoint.y)
+    mouseMoveVersion += 1
     scheduleMouseMove()
   }
 

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -107,10 +107,13 @@ export function useModel() {
     live2d.setParameterValue(id, pressed)
   }
 
-  async function handleMouseMove(cursorPoint: PhysicalPosition) {
+  async function handleMouseMove(
+    cursorPoint: PhysicalPosition,
+    { isLatest = () => true }: { isLatest?: () => boolean } = {},
+  ) {
     const monitor = await getCursorMonitor(cursorPoint)
 
-    if (!monitor) return
+    if (!monitor || !isLatest()) return
 
     const { size, position } = monitor
 


### PR DESCRIPTION
## Summary

This PR fixes visible mouse-follow jitter/twitching when using high polling rate mice (for example 800Hz / 1000Hz / 2000Hz).

The issue was caused by handling every `MouseMove` event too aggressively on the frontend:
- each event triggered fresh async cursor-follow work
- high input frequency created unnecessary async pressure
- older async results could complete later and overwrite newer state

This patch keeps the fix scoped to the mousemove path and:
- uses the `MouseMove` payload directly
- throttles mousemove-driven updates to ~60fps (`16ms`)
- drops stale async follow results before they can write back

## Why

High polling rate input should not map 1:1 to visual updates.

For cursor-follow animation, what matters is applying the latest cursor position at a stable update cadence, instead of processing every historical mousemove event. This reduces event flood pressure and avoids stale async write-back, which was causing visible jitter.

## Scope

This PR is intentionally limited to the high polling rate mousemove jitter issue.

Included:
- frontend `MouseMove` payload usage
- frontend mousemove throttling
- stale async result guard

Not included:
- backend mousemove throttling/coalescing
- monitor caching
- unrelated performance refactors

## Expected result

- behavior at 500Hz and below should remain unchanged
- 1000Hz should become stable without obvious twitching
- 2000Hz should avoid visible backlog-style jitter
- mouse clicks, keyboard input, and basic hide-on-hover behavior should remain unchanged