### PR TITLE
feat: 支持使用快捷键触发模型动作与表情

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@antfu/eslint-config": "^4.13.3",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
-    "@iconify-json/iconamoon": "^1.2.2",
+    "@iconify-json/lucide": "^1.2.83",
     "@iconify-json/solar": "^1.2.2",
     "@tauri-apps/cli": "^2.5.0",
     "@types/is-url": "^1.2.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,16 +101,16 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^4.13.3
-        version: 4.13.3(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(@unocss/eslint-plugin@66.1.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(@vue/compiler-sfc@3.5.16)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+        version: 4.13.3(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(@unocss/eslint-plugin@66.1.3(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(@vue/compiler-sfc@3.5.16)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.6.1)))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@22.15.29)(typescript@5.6.3)
       '@commitlint/config-conventional':
         specifier: ^19.8.1
         version: 19.8.1
-      '@iconify-json/iconamoon':
-        specifier: ^1.2.2
-        version: 1.2.2
+      '@iconify-json/lucide':
+        specifier: ^1.2.83
+        version: 1.2.83
       '@iconify-json/solar':
         specifier: ^1.2.2
         version: 1.2.2
@@ -125,16 +125,16 @@ importers:
         version: 22.15.29
       '@unocss/eslint-plugin':
         specifier: ^66.1.3
-        version: 66.1.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+        version: 66.1.3(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       '@vitejs/plugin-vue':
         specifier: ^5.2.4
-        version: 5.2.4(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
+        version: 5.2.4(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
       eslint:
         specifier: ^9.28.0
-        version: 9.28.0(jiti@2.4.2)
+        version: 9.28.0(jiti@2.6.1)
       eslint-plugin-format:
         specifier: ^1.0.1
-        version: 1.0.1(eslint@9.28.0(jiti@2.4.2))
+        version: 1.0.1(eslint@9.28.0(jiti@2.6.1))
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
@@ -158,10 +158,10 @@ importers:
         version: 5.6.3
       unocss:
         specifier: 66.1.0-beta.7
-        version: 66.1.0-beta.7(postcss@8.5.4)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
+        version: 66.1.0-beta.7(postcss@8.5.4)(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
+        version: 6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
 
 packages:
 
@@ -609,8 +609,8 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@iconify-json/iconamoon@1.2.2':
-    resolution: {integrity: sha512-Xn7YeSDniPgutPr0qil/iQwQelq975OYQ/i2twGjcK4DjGOXBrBC+6q45WtVuQbFfXzM7bgijv4yVnxy0OqUdQ==}
+  '@iconify-json/lucide@1.2.83':
+    resolution: {integrity: sha512-k/255BFdcE+gY8cwQOlJMKjxOScW++8tiMxWw8jJXqHoQhBmOgsxm8SHVUIZqSrquMCcSNJn6rx67ZTQhoR2cA==}
 
   '@iconify-json/solar@1.2.2':
     resolution: {integrity: sha512-lcTb6DWL4HZObiY1W3fHfuxxuQHUc6CFHFeywKEx7Ry0k+dU6POZCMC7oVLr0F8vuf+KgaQ3oOoGO/yFzOwrNg==}
@@ -3188,6 +3188,10 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4845,48 +4849,48 @@ snapshots:
       '@ant-design/icons-svg': 4.4.2
       vue: 3.5.16(typescript@5.6.3)
 
-  '@antfu/eslint-config@4.13.3(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(@unocss/eslint-plugin@66.1.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(@vue/compiler-sfc@3.5.16)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@antfu/eslint-config@4.13.3(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(@unocss/eslint-plugin@66.1.3(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(@vue/compiler-sfc@3.5.16)(eslint-import-resolver-node@0.3.9)(eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.6.1)))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
-      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.28.0(jiti@2.6.1))
       '@eslint/markdown': 6.4.0
-      '@stylistic/eslint-plugin': 5.0.0-beta.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      '@typescript-eslint/eslint-plugin': 8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      '@vitest/eslint-plugin': 1.2.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@stylistic/eslint-plugin': 5.0.0-beta.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      '@vitest/eslint-plugin': 1.2.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       ansis: 4.1.0
       cac: 6.7.14
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-config-flat-gitignore: 2.1.0(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-config-flat-gitignore: 2.1.0(eslint@9.28.0(jiti@2.6.1))
       eslint-flat-config-utils: 2.1.0
-      eslint-merge-processors: 2.0.0(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-antfu: 3.1.1(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-command: 3.2.1(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-import-x: 4.15.0(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-jsdoc: 50.7.1(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-jsonc: 2.20.1(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-n: 17.19.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      eslint-merge-processors: 2.0.0(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-antfu: 3.1.1(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-command: 3.2.1(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-import-x: 4.15.0(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-jsdoc: 50.7.1(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-jsonc: 2.20.1(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-n: 17.19.0(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-perfectionist: 4.14.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      eslint-plugin-pnpm: 0.3.1(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-regexp: 2.8.0(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-toml: 0.12.0(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-unicorn: 59.0.1(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-vue: 10.1.0(eslint@9.28.0(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.28.0(jiti@2.4.2)))
-      eslint-plugin-yml: 1.18.0(eslint@9.28.0(jiti@2.4.2))
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-perfectionist: 4.14.0(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      eslint-plugin-pnpm: 0.3.1(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-regexp: 2.8.0(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-toml: 0.12.0(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-unicorn: 59.0.1(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1))
+      eslint-plugin-vue: 10.1.0(eslint@9.28.0(jiti@2.6.1))(vue-eslint-parser@10.1.3(eslint@9.28.0(jiti@2.6.1)))
+      eslint-plugin-yml: 1.18.0(eslint@9.28.0(jiti@2.6.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.6.1))
       globals: 16.2.0
       jsonc-eslint-parser: 2.4.0
       local-pkg: 1.1.1
       parse-gitignore: 2.0.0
       toml-eslint-parser: 0.10.0
-      vue-eslint-parser: 10.1.3(eslint@9.28.0(jiti@2.4.2))
+      vue-eslint-parser: 10.1.3(eslint@9.28.0(jiti@2.6.1))
       yaml-eslint-parser: 1.3.0
     optionalDependencies:
-      '@unocss/eslint-plugin': 66.1.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      eslint-plugin-format: 1.0.1(eslint@9.28.0(jiti@2.4.2))
+      '@unocss/eslint-plugin': 66.1.3(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      eslint-plugin-format: 1.0.1(eslint@9.28.0(jiti@2.6.1))
     transitivePeerDependencies:
       - '@eslint/json'
       - '@typescript-eslint/utils'
@@ -5156,22 +5160,22 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.28.0(jiti@2.4.2))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.28.0(jiti@2.6.1))':
     dependencies:
       escape-string-regexp: 4.0.0
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       ignore: 5.3.2
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.4.2))':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.28.0(jiti@2.6.1))':
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/compat@1.2.9(eslint@9.28.0(jiti@2.4.2))':
+  '@eslint/compat@1.2.9(eslint@9.28.0(jiti@2.6.1))':
     optionalDependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
 
   '@eslint/config-array@0.20.0':
     dependencies:
@@ -5250,7 +5254,7 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@iconify-json/iconamoon@1.2.2':
+  '@iconify-json/lucide@1.2.83':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -5892,10 +5896,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@stylistic/eslint-plugin@5.0.0-beta.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@stylistic/eslint-plugin@5.0.0-beta.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      eslint: 9.28.0(jiti@2.4.2)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      eslint: 9.28.0(jiti@2.6.1)
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0
       estraverse: 5.3.0
@@ -6050,15 +6054,15 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.33.1
-      '@typescript-eslint/type-utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.33.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -6067,14 +6071,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.33.1
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.33.1
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -6097,12 +6101,12 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  '@typescript-eslint/type-utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -6126,13 +6130,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.33.1
       '@typescript-eslint/types': 8.33.1
       '@typescript-eslint/typescript-estree': 8.33.1(typescript@5.6.3)
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -6142,13 +6146,13 @@ snapshots:
       '@typescript-eslint/types': 8.33.1
       eslint-visitor-keys: 4.2.0
 
-  '@unocss/astro@66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))':
+  '@unocss/astro@66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))':
     dependencies:
       '@unocss/core': 66.1.0-beta.7
       '@unocss/reset': 66.1.0-beta.7
-      '@unocss/vite': 66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
+      '@unocss/vite': 66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - vue
 
@@ -6182,9 +6186,9 @@ snapshots:
 
   '@unocss/core@66.1.3': {}
 
-  '@unocss/eslint-plugin@66.1.3(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@unocss/eslint-plugin@66.1.3(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       '@unocss/config': 66.1.3
       '@unocss/core': 66.1.3
       '@unocss/rule-utils': 66.1.3
@@ -6304,7 +6308,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.1.0-beta.7
 
-  '@unocss/vite@66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))':
+  '@unocss/vite@66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.1.0-beta.7
@@ -6314,7 +6318,7 @@ snapshots:
       magic-string: 0.30.17
       tinyglobby: 0.2.14
       unplugin-utils: 0.2.4
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - vue
 
@@ -6371,15 +6375,15 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.7.9':
     optional: true
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))':
     dependencies:
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
       vue: 3.5.16(typescript@5.6.3)
 
-  '@vitest/eslint-plugin@1.2.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)':
+  '@vitest/eslint-plugin@1.2.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      eslint: 9.28.0(jiti@2.4.2)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      eslint: 9.28.0(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -7118,28 +7122,28 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-compat-utils@0.5.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       semver: 7.7.2
 
-  eslint-compat-utils@0.6.5(eslint@9.28.0(jiti@2.4.2)):
+  eslint-compat-utils@0.6.5(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       semver: 7.7.2
 
-  eslint-config-flat-gitignore@2.1.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-config-flat-gitignore@2.1.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      '@eslint/compat': 1.2.9(eslint@9.28.0(jiti@2.4.2))
-      eslint: 9.28.0(jiti@2.4.2)
+      '@eslint/compat': 1.2.9(eslint@9.28.0(jiti@2.6.1))
+      eslint: 9.28.0(jiti@2.6.1)
 
   eslint-flat-config-utils@2.1.0:
     dependencies:
       pathe: 2.0.3
 
-  eslint-formatting-reporter@0.0.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-formatting-reporter@0.0.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       prettier-linter-helpers: 1.0.0
 
   eslint-import-context@0.1.7(unrs-resolver@1.7.9):
@@ -7158,51 +7162,51 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-json-compat-utils@0.2.1(eslint@9.28.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0):
+  eslint-json-compat-utils@0.2.1(eslint@9.28.0(jiti@2.6.1))(jsonc-eslint-parser@2.4.0):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       esquery: 1.6.0
       jsonc-eslint-parser: 2.4.0
 
-  eslint-merge-processors@2.0.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-merge-processors@2.0.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
 
   eslint-parser-plain@0.1.1: {}
 
-  eslint-plugin-antfu@3.1.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-antfu@3.1.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
 
-  eslint-plugin-command@3.2.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-command@3.2.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
 
-  eslint-plugin-es-x@7.8.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-es-x@7.8.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-compat-utils: 0.5.1(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-compat-utils: 0.5.1(eslint@9.28.0(jiti@2.6.1))
 
-  eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-format@1.0.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       '@dprint/formatter': 0.3.0
       '@dprint/markdown': 0.17.8
       '@dprint/toml': 0.6.4
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-formatting-reporter: 0.0.0(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-formatting-reporter: 0.0.0(eslint@9.28.0(jiti@2.6.1))
       eslint-parser-plain: 0.1.1
       prettier: 3.5.3
       synckit: 0.9.3
 
-  eslint-plugin-import-x@4.15.0(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-import-x@4.15.0(@typescript-eslint/utils@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       '@typescript-eslint/types': 8.33.1
       comment-parser: 1.4.1
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       eslint-import-context: 0.1.7(unrs-resolver@1.7.9)
       is-glob: 4.0.3
       minimatch: 10.0.1
@@ -7210,19 +7214,19 @@ snapshots:
       stable-hash: 0.0.5
       unrs-resolver: 1.7.9
     optionalDependencies:
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@50.7.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-jsdoc@50.7.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       '@es-joy/jsdoccomment': 0.50.2
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
       debug: 4.4.1
       escape-string-regexp: 4.0.0
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       espree: 10.3.0
       esquery: 1.6.0
       parse-imports-exports: 0.2.4
@@ -7231,12 +7235,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsonc@2.20.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-jsonc@2.20.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-compat-utils: 0.6.5(eslint@9.28.0(jiti@2.4.2))
-      eslint-json-compat-utils: 0.2.1(eslint@9.28.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-compat-utils: 0.6.5(eslint@9.28.0(jiti@2.6.1))
+      eslint-json-compat-utils: 0.2.1(eslint@9.28.0(jiti@2.6.1))(jsonc-eslint-parser@2.4.0)
       espree: 10.3.0
       graphemer: 1.4.0
       jsonc-eslint-parser: 2.4.0
@@ -7245,13 +7249,13 @@ snapshots:
     transitivePeerDependencies:
       - '@eslint/json'
 
-  eslint-plugin-n@17.19.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3):
+  eslint-plugin-n@17.19.0(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
       enhanced-resolve: 5.18.1
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-plugin-es-x: 7.8.0(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-plugin-es-x: 7.8.0(eslint@9.28.0(jiti@2.6.1))
       get-tsconfig: 4.10.1
       globals: 15.15.0
       ignore: 5.3.2
@@ -7264,19 +7268,19 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-perfectionist@4.14.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3):
+  eslint-plugin-perfectionist@4.14.0(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/types': 8.33.1
-      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
-      eslint: 9.28.0(jiti@2.4.2)
+      '@typescript-eslint/utils': 8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
+      eslint: 9.28.0(jiti@2.6.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-pnpm@0.3.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-pnpm@0.3.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       find-up-simple: 1.0.1
       jsonc-eslint-parser: 2.4.0
       pathe: 2.0.3
@@ -7284,36 +7288,36 @@ snapshots:
       tinyglobby: 0.2.14
       yaml-eslint-parser: 1.3.0
 
-  eslint-plugin-regexp@2.8.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-regexp@2.8.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
       comment-parser: 1.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       jsdoc-type-pratt-parser: 4.1.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-toml@0.12.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-toml@0.12.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-compat-utils: 0.6.5(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-compat-utils: 0.6.5(eslint@9.28.0(jiti@2.6.1))
       lodash: 4.17.21
       toml-eslint-parser: 0.10.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@59.0.1(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-unicorn@59.0.1(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
       '@eslint/plugin-kit': 0.2.8
       ci-info: 4.2.0
       clean-regexp: 1.0.0
       core-js-compat: 3.42.0
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       esquery: 1.6.0
       find-up-simple: 1.0.1
       globals: 16.2.0
@@ -7326,38 +7330,38 @@ snapshots:
       semver: 7.7.2
       strip-indent: 4.0.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3))(eslint@9.28.0(jiti@2.4.2))(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 8.33.1(@typescript-eslint/parser@8.33.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3))(eslint@9.28.0(jiti@2.6.1))(typescript@5.6.3)
 
-  eslint-plugin-vue@10.1.0(eslint@9.28.0(jiti@2.4.2))(vue-eslint-parser@10.1.3(eslint@9.28.0(jiti@2.4.2))):
+  eslint-plugin-vue@10.1.0(eslint@9.28.0(jiti@2.6.1))(vue-eslint-parser@10.1.3(eslint@9.28.0(jiti@2.6.1))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
-      eslint: 9.28.0(jiti@2.4.2)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
+      eslint: 9.28.0(jiti@2.6.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.7.2
-      vue-eslint-parser: 10.1.3(eslint@9.28.0(jiti@2.4.2))
+      vue-eslint-parser: 10.1.3(eslint@9.28.0(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
-  eslint-plugin-yml@1.18.0(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-yml@1.18.0(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       debug: 4.4.1
       escape-string-regexp: 4.0.0
-      eslint: 9.28.0(jiti@2.4.2)
-      eslint-compat-utils: 0.6.5(eslint@9.28.0(jiti@2.4.2))
+      eslint: 9.28.0(jiti@2.6.1)
+      eslint-compat-utils: 0.6.5(eslint@9.28.0(jiti@2.6.1))
       natural-compare: 1.4.0
       yaml-eslint-parser: 1.3.0
     transitivePeerDependencies:
       - supports-color
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.4.2)):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.16)(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       '@vue/compiler-sfc': 3.5.16
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
 
   eslint-scope@8.3.0:
     dependencies:
@@ -7368,9 +7372,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.28.0(jiti@2.4.2):
+  eslint@9.28.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.28.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0
       '@eslint/config-helpers': 0.2.2
@@ -7406,7 +7410,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.4.2
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8012,6 +8016,9 @@ snapshots:
       lodash.uniqby: 4.7.0
 
   jiti@2.4.2: {}
+
+  jiti@2.6.1:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -9637,9 +9644,9 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  unocss@66.1.0-beta.7(postcss@8.5.4)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3)):
+  unocss@66.1.0-beta.7(postcss@8.5.4)(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3)):
     dependencies:
-      '@unocss/astro': 66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
+      '@unocss/astro': 66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
       '@unocss/cli': 66.1.0-beta.7
       '@unocss/core': 66.1.0-beta.7
       '@unocss/postcss': 66.1.0-beta.7(postcss@8.5.4)
@@ -9657,9 +9664,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.1.0-beta.7
       '@unocss/transformer-directives': 66.1.0-beta.7
       '@unocss/transformer-variant-group': 66.1.0-beta.7
-      '@unocss/vite': 66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
+      '@unocss/vite': 66.1.0-beta.7(vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0))(vue@3.5.16(typescript@5.6.3))
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -9729,7 +9736,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0):
+  vite@6.3.5(@types/node@22.15.29)(jiti@2.6.1)(lightningcss@1.29.2)(sass@1.89.1)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.5(picomatch@4.0.2)
@@ -9740,16 +9747,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.29
       fsevents: 2.3.3
-      jiti: 2.4.2
+      jiti: 2.6.1
       lightningcss: 1.29.2
       sass: 1.89.1
       tsx: 4.19.4
       yaml: 2.8.0
 
-  vue-eslint-parser@10.1.3(eslint@9.28.0(jiti@2.4.2)):
+  vue-eslint-parser@10.1.3(eslint@9.28.0(jiti@2.6.1)):
     dependencies:
       debug: 4.4.1
-      eslint: 9.28.0(jiti@2.4.2)
+      eslint: 9.28.0(jiti@2.6.1)
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.0
       espree: 10.3.0

--- a/src/components/shortcut/index.vue
+++ b/src/components/shortcut/index.vue
@@ -4,13 +4,7 @@ import type { Key } from '@/utils/keyboard'
 import { find, map, remove, some, split } from 'es-toolkit/compat'
 import { ref, useTemplateRef, watch } from 'vue'
 
-import ProListItem from '@/components/pro-list-item/index.vue'
 import { keys, modifierKeys, standardKeys } from '@/utils/keyboard'
-
-const props = defineProps<{
-  title: string
-  description?: string
-}>()
 
 const modelValue = defineModel<string>()
 const shortcutInputRef = useTemplateRef('shortcutInput')
@@ -95,33 +89,29 @@ function handleKeyUp(event: KeyboardEvent) {
 </script>
 
 <template>
-  <ProListItem v-bind="props">
+  <div
+    ref="shortcutInput"
+    class="relative h-8 min-w-32 flex cursor-text items-center justify-center b b-color-1 hover:b-primary-5 rounded-md b-solid px-2.5 text-color-3 outline-none transition focus:(b-primary shadow-[0_0_0_2px_rgba(5,145,255,0.1)])"
+    :tabindex="0"
+    @blur="handleBlur"
+    @focus="handleFocus"
+    @keydown="handleKeyDown"
+    @keyup="handleKeyUp"
+    @mouseout="isHovering = false"
+    @mouseover="isHovering = true"
+  >
+    <span v-if="pressedKeys.length === 0">
+      {{ isFocusing ? $t('components.shortcut.hints.pressRecordShortcut') : $t('components.shortcut.hints.clickRecordShortcut') }}
+    </span>
+
+    <span class="text-primary font-bold">
+      {{ map(pressedKeys, 'symbol').join(' ') }}
+    </span>
+
     <div
-      ref="shortcutInput"
-      align="center"
-      class="relative h-8 min-w-32 flex cursor-text items-center justify-center b b-color-1 hover:b-primary-5 rounded-md b-solid px-2.5 text-color-3 outline-none transition focus:(b-primary shadow-[0_0_0_2px_rgba(5,145,255,0.1)])"
-      justify="center"
-      :tabindex="0"
-      @blur="handleBlur"
-      @focus="handleFocus"
-      @keydown="handleKeyDown"
-      @keyup="handleKeyUp"
-      @mouseout="isHovering = false"
-      @mouseover="isHovering = true"
-    >
-      <span v-if="pressedKeys.length === 0">
-        {{ isFocusing ? $t('components.proShortcut.hints.pressRecordShortcut') : $t('components.proShortcut.hints.clickRecordShortcut') }}
-      </span>
-
-      <span class="text-primary font-bold">
-        {{ map(pressedKeys, 'symbol').join(' ') }}
-      </span>
-
-      <div
-        class="i-iconamoon:close-circle-1 absolute right-2 cursor-pointer text-4 transition hover:text-primary"
-        :hidden="isFocusing || !isHovering || pressedKeys.length === 0"
-        @mousedown.prevent="modelValue = ''"
-      />
-    </div>
-  </ProListItem>
+      class="i-lucide:circle-x absolute right-2 cursor-pointer text-4 transition hover:text-primary"
+      :hidden="isFocusing || !isHovering || pressedKeys.length === 0"
+      @mousedown.prevent="modelValue = ''"
+    />
+  </div>
 </template>

--- a/src/composables/useKeyPress.ts
+++ b/src/composables/useKeyPress.ts
@@ -8,7 +8,8 @@ import {
 } from '@tauri-apps/plugin-global-shortcut'
 import { ref, watch } from 'vue'
 
-export function useTauriShortcut(shortcut: Ref<string, string>, callback: ShortcutHandler) {
+export function useKeyPress(shortcut: Ref<string | undefined, string>, callback: ShortcutHandler) {
+  // This is primarily to prevent errors during hot reloading in the development environment.
   const oldShortcut = ref(shortcut.value)
 
   watch(shortcut, async (value) => {
@@ -27,7 +28,5 @@ export function useTauriShortcut(shortcut: Ref<string, string>, callback: Shortc
 
       callback(event)
     })
-
-    oldShortcut.value = value
   }, { immediate: true })
 }

--- a/src/composables/useKeyPress.ts
+++ b/src/composables/useKeyPress.ts
@@ -28,5 +28,7 @@ export function useKeyPress(shortcut: Ref<string | undefined, string>, callback:
 
       callback(event)
     })
+
+    oldShortcut.value = value
   }, { immediate: true })
 }

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -4,7 +4,7 @@ import { LogicalSize } from '@tauri-apps/api/dpi'
 import { resolveResource, sep } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { message } from 'ant-design-vue'
-import { isNil, round } from 'es-toolkit'
+import { isNil, range, round } from 'es-toolkit'
 import { nth } from 'es-toolkit/compat'
 import { ref } from 'vue'
 
@@ -13,8 +13,10 @@ import live2d from '../utils/live2d'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { getCursorMonitor } from '@/utils/monitor'
+import { isMac } from '@/utils/platform'
 
 const appWindow = getCurrentWebviewWindow()
+const digitKeys = [...range(1, 10), 0] as const
 
 export interface ModelSize {
   width: number
@@ -26,6 +28,34 @@ export function useModel() {
   const catStore = useCatStore()
   const modelSize = ref<ModelSize>()
 
+  const getBehaviorShortcut = (index: number) => {
+    const tier = Math.floor(index / digitKeys.length)
+
+    if (tier >= 3) return ''
+
+    const primary = isMac ? 'Command' : 'Control'
+    const key = digitKeys[index % digitKeys.length]
+    const modifiers = [primary]
+
+    if (tier >= 1) {
+      modifiers.push('Shift')
+    }
+
+    if (tier >= 2) {
+      modifiers.push('Alt')
+    }
+
+    return [...modifiers, key].join('+')
+  }
+
+  const getMotionShortcutId = (modelId: string, groupName: string, index: number) => {
+    return `${modelId}:motion:${groupName}:${index}`
+  }
+
+  const getExpressionShortcutId = (modelId: string, index: number) => {
+    return `${modelId}:expression:${index}`
+  }
+
   async function handleLoad() {
     try {
       if (!modelStore.currentModel) return
@@ -34,13 +64,39 @@ export function useModel() {
 
       await resolveResource(path)
 
-      const { width, height, ...rest } = await live2d.load(path)
+      const { width, height, motions = {}, expressions = [] } = await live2d.load(path)
+
+      const nextMotions = Object.entries(motions)
 
       modelSize.value = { width, height }
+      modelStore.currentMotions = nextMotions
+      modelStore.currentExpressions = expressions
 
       handleResize()
 
-      Object.assign(modelStore, rest)
+      const modelId = modelStore.currentModel.id
+
+      const behaviorIds: string[] = []
+
+      for (const [groupName, items] of nextMotions) {
+        for (const [index] of items.entries()) {
+          behaviorIds.push(getMotionShortcutId(modelId, groupName, index))
+        }
+      }
+
+      for (const [index] of expressions.entries()) {
+        behaviorIds.push(getExpressionShortcutId(modelId, index))
+      }
+
+      for (const [index, id] of behaviorIds.entries()) {
+        if (modelStore.shortcuts[id]) continue
+
+        const shortcut = getBehaviorShortcut(index)
+
+        if (!shortcut) continue
+
+        modelStore.shortcuts[id] = shortcut
+      }
     } catch (error) {
       message.error(String(error))
     }
@@ -79,9 +135,11 @@ export function useModel() {
     if (catStore.model.single) {
       const dirName = nth(path.split(sep()), -2)!
 
-      const filterKeys = Object.entries(modelStore.pressedKeys).filter(([, value]) => {
-        return value.includes(dirName)
-      })
+      const filterKeys = Object.entries(modelStore.pressedKeys).filter(
+        ([, value]) => {
+          return value.includes(dirName)
+        },
+      )
 
       for (const [key] of filterKeys) {
         handleRelease(key)
@@ -117,7 +175,12 @@ export function useModel() {
     const xRatio = (cursorPoint.x - position.x) / size.width
     const yRatio = (cursorPoint.y - position.y) / size.height
 
-    for (const id of ['ParamMouseX', 'ParamMouseY', 'ParamAngleX', 'ParamAngleY']) {
+    for (const id of [
+      'ParamMouseX',
+      'ParamMouseY',
+      'ParamAngleX',
+      'ParamAngleY',
+    ]) {
       const { min, max } = live2d.getParameterRange(id)
 
       if (isNil(min) || isNil(max)) continue
@@ -125,7 +188,7 @@ export function useModel() {
       const isXAxis = id.endsWith('X')
 
       const ratio = isXAxis ? xRatio : yRatio
-      let value = max - (ratio * (max - min))
+      let value = max - ratio * (max - min)
 
       if (isXAxis && catStore.model.mouseMirror) {
         value *= -1

--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -4,7 +4,7 @@ import { LogicalSize } from '@tauri-apps/api/dpi'
 import { resolveResource, sep } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { message } from 'ant-design-vue'
-import { isNil, range, round } from 'es-toolkit'
+import { isNil, round } from 'es-toolkit'
 import { nth } from 'es-toolkit/compat'
 import { ref } from 'vue'
 
@@ -16,7 +16,8 @@ import { getCursorMonitor } from '@/utils/monitor'
 import { isMac } from '@/utils/platform'
 
 const appWindow = getCurrentWebviewWindow()
-const digitKeys = [...range(1, 10), 0] as const
+const digitKeys = '1234567890'.split('') as readonly string[]
+const letterKeys = 'QWERTYUIOPASDFGHJKLZXCVBNM'.split('') as readonly string[]
 
 export interface ModelSize {
   width: number
@@ -28,31 +29,39 @@ export function useModel() {
   const catStore = useCatStore()
   const modelSize = ref<ModelSize>()
 
-  const getBehaviorShortcut = (index: number) => {
-    const tier = Math.floor(index / digitKeys.length)
-
-    if (tier >= 3) return ''
-
+  function getBehaviorShortcut(index: number) {
     const primary = isMac ? 'Command' : 'Control'
-    const key = digitKeys[index % digitKeys.length]
-    const modifiers = [primary]
 
-    if (tier >= 1) {
-      modifiers.push('Shift')
+    const modifierGroups = [
+      [primary],
+      [primary, 'Shift'],
+      [primary, 'Alt'],
+      [primary, 'Shift', 'Alt'],
+    ]
+
+    const tiers = [
+      ...modifierGroups.map(modifiers => ({ modifiers, keys: digitKeys })),
+      ...modifierGroups.map(modifiers => ({ modifiers, keys: letterKeys })),
+    ]
+
+    let nextIndex = index
+
+    for (const tier of tiers) {
+      if (nextIndex < tier.keys.length) {
+        return [...tier.modifiers, tier.keys[nextIndex]].join('+')
+      }
+
+      nextIndex -= tier.keys.length
     }
 
-    if (tier >= 2) {
-      modifiers.push('Alt')
-    }
-
-    return [...modifiers, key].join('+')
+    return ''
   }
 
-  const getMotionShortcutId = (modelId: string, groupName: string, index: number) => {
+  function getMotionShortcutId(modelId: string, groupName: string, index: number) {
     return `${modelId}:motion:${groupName}:${index}`
   }
 
-  const getExpressionShortcutId = (modelId: string, index: number) => {
+  function getExpressionShortcutId(modelId: string, index: number) {
     return `${modelId}:expression:${index}`
   }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,6 +8,8 @@ export const LISTEN_KEY = {
   DEVICE_CHANGED: 'device-changed',
   UPDATE_APP: 'update-app',
   GAMEPAD_CHANGED: 'gamepad-changed',
+  PLAY_MOTION: 'play-motion',
+  PLAY_EXPRESSION: 'play-expression',
 }
 
 export const INVOKE_KEY = {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -90,6 +90,16 @@
           "createModel": "Create Model",
           "convertModel": "Convert Model",
           "moreModels": "More Models"
+        },
+        "behaviorModal": {
+          "title": "Motions and Expressions",
+          "labels": {
+            "motion": "Motion",
+            "expression": "Expression",
+            "motionIndex": "Motion {index}",
+            "motionGroupIndex": "Motion Group {index}",
+            "expressionIndex": "Expression {index}"
+          }
         }
       },
       "shortcut": {
@@ -131,7 +141,7 @@
     }
   },
   "components": {
-    "proShortcut": {
+    "shortcut": {
       "hints": {
         "pressRecordShortcut": "Press to record shortcut",
         "clickRecordShortcut": "Click to record shortcut"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -90,6 +90,16 @@
           "createModel": "Criar modelo",
           "convertModel": "Converter modelo",
           "moreModels": "Mais modelos"
+        },
+        "behaviorModal": {
+          "title": "Movimentos e Expressões",
+          "labels": {
+            "motion": "Movimento",
+            "expression": "Expressão",
+            "motionIndex": "Movimento {index}",
+            "motionGroupIndex": "Grupo de Movimento {index}",
+            "expressionIndex": "Expressão {index}"
+          }
         }
       },
       "shortcut": {
@@ -131,7 +141,7 @@
     }
   },
   "components": {
-    "proShortcut": {
+    "shortcut": {
       "hints": {
         "pressRecordShortcut": "Pressione as teclas para gravar atalho",
         "clickRecordShortcut": "Clique para gravar atalho"

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -90,6 +90,16 @@
           "createModel": "Tạo mô hình",
           "convertModel": "Chuyển đổi mô hình",
           "moreModels": "Khám phá mô hình khác"
+        },
+        "behaviorModal": {
+          "title": "Chuyển động và Biểu cảm",
+          "labels": {
+            "motion": "Chuyển động",
+            "expression": "Biểu cảm",
+            "motionIndex": "Chuyển động {index}",
+            "motionGroupIndex": "Nhóm chuyển động {index}",
+            "expressionIndex": "Biểu cảm {index}"
+          }
         }
       },
       "shortcut": {
@@ -131,7 +141,7 @@
     }
   },
   "components": {
-    "proShortcut": {
+    "shortcut": {
       "hints": {
         "pressRecordShortcut": "Nhấn phím/tổ hợp phím để ghi",
         "clickRecordShortcut": "Click để ghi phím tắt"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -90,6 +90,16 @@
           "createModel": "制作模型",
           "convertModel": "转换模型",
           "moreModels": "更多模型"
+        },
+        "behaviorModal": {
+          "title": "动作与表情",
+          "labels": {
+            "motion": "动作",
+            "expression": "表情",
+            "motionIndex": "动作{index}",
+            "motionGroupIndex": "动作组{index}",
+            "expressionIndex": "表情{index}"
+          }
         }
       },
       "shortcut": {
@@ -131,7 +141,7 @@
     }
   },
   "components": {
-    "proShortcut": {
+    "shortcut": {
       "hints": {
         "pressRecordShortcut": "按下录制快捷键",
         "clickRecordShortcut": "点击录制快捷键"

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -90,6 +90,16 @@
           "createModel": "製作模型",
           "convertModel": "轉換模型",
           "moreModels": "更多模型"
+        },
+        "behaviorModal": {
+          "title": "動作與表情",
+          "labels": {
+            "motion": "動作",
+            "expression": "表情",
+            "motionIndex": "動作{index}",
+            "motionGroupIndex": "動作組{index}",
+            "expressionIndex": "表情{index}"
+          }
         }
       },
       "shortcut": {
@@ -131,7 +141,7 @@
     }
   },
   "components": {
-    "proShortcut": {
+    "shortcut": {
       "hints": {
         "pressRecordShortcut": "按下錄製快速鍵",
         "clickRecordShortcut": "點擊錄製快速鍵"

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -38,9 +38,7 @@ const backgroundImagePath = ref<string>()
 const { stickActive } = useGamepad()
 const { isMounted, setWindowPosition } = useWindowPosition()
 
-onMounted(() => {
-  startListening()
-})
+onMounted(startListening)
 
 onUnmounted(handleDestroy)
 

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -14,12 +14,15 @@ import { useDevice } from '@/composables/useDevice'
 import { useGamepad } from '@/composables/useGamepad'
 import { useModel } from '@/composables/useModel'
 import { useSharedMenu } from '@/composables/useSharedMenu'
+import { useTauriListen } from '@/composables/useTauriListen'
 import { useWindowPosition } from '@/composables/useWindowPosition'
+import { LISTEN_KEY } from '@/constants'
 import { hideWindow, setAlwaysOnTop, setTaskbarVisibility, showWindow } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
 import { useGeneralStore } from '@/stores/general.ts'
 import { useModelStore } from '@/stores/model'
 import { isImage } from '@/utils/is'
+import live2d from '@/utils/live2d'
 import { join } from '@/utils/path'
 import { clearObject } from '@/utils/shared'
 
@@ -35,7 +38,9 @@ const backgroundImagePath = ref<string>()
 const { stickActive } = useGamepad()
 const { isMounted, setWindowPosition } = useWindowPosition()
 
-onMounted(startListening)
+onMounted(() => {
+  startListening()
+})
 
 onUnmounted(handleDestroy)
 
@@ -120,6 +125,16 @@ watch(() => catStore.window.passThrough, (value) => {
 watch(() => catStore.window.alwaysOnTop, setAlwaysOnTop, { immediate: true })
 
 watch(() => generalStore.app.taskbarVisible, setTaskbarVisibility, { immediate: true })
+
+useTauriListen<{ group: string, index: number }>(LISTEN_KEY.PLAY_MOTION, ({ payload }) => {
+  const { group, index } = payload
+
+  live2d.playMotion(group, index)
+})
+
+useTauriListen<number>(LISTEN_KEY.PLAY_EXPRESSION, ({ payload }) => {
+  live2d.playExpressions(payload)
+})
 
 function handleMouseDown() {
   appWindow.startDragging()

--- a/src/pages/preference/components/model/components/behavior-modal/components/behavior-item/index.vue
+++ b/src/pages/preference/components/model/components/behavior-modal/components/behavior-item/index.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { Button, ListItem } from 'ant-design-vue'
+
+import Shortcut from '@/components/shortcut/index.vue'
+import { useKeyPress } from '@/composables/useKeyPress'
+
+const { label } = defineProps<{ label: string }>()
+const emit = defineEmits(['click'])
+const modelValue = defineModel<string>()
+
+useKeyPress(modelValue, () => {
+  emit('click')
+})
+</script>
+
+<template>
+  <ListItem>
+    <span>{{ label }}</span>
+
+    <template #actions>
+      <Shortcut v-model="modelValue" />
+
+      <Button
+        class="inline-flex items-center justify-center"
+        @click="emit('click')"
+      >
+        <template #icon>
+          <div class="i-lucide:play" />
+        </template>
+      </Button>
+    </template>
+  </ListItem>
+</template>

--- a/src/pages/preference/components/model/components/behavior-modal/index.vue
+++ b/src/pages/preference/components/model/components/behavior-modal/index.vue
@@ -2,7 +2,7 @@
 import { emit } from '@tauri-apps/api/event'
 import { Empty, List, Modal, Segmented } from 'ant-design-vue'
 import { isEmpty } from 'es-toolkit/compat'
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 
 import BehaviorItem from './components/behavior-item/index.vue'
 
@@ -12,10 +12,6 @@ import { useModelStore } from '@/stores/model'
 const modelValue = defineModel<boolean>()
 const modelStore = useModelStore()
 const value = ref<'motion' | 'expression'>('motion')
-
-watch(modelValue, () => {
-  value.value = 'motion'
-})
 
 function getMotionShortcutId(groupName: string, index: number) {
   return `${modelStore.currentModel?.id}:motion:${groupName}:${index}`

--- a/src/pages/preference/components/model/components/behavior-modal/index.vue
+++ b/src/pages/preference/components/model/components/behavior-modal/index.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { emit } from '@tauri-apps/api/event'
+import { Empty, List, Modal, Segmented } from 'ant-design-vue'
+import { isEmpty } from 'es-toolkit/compat'
+import { ref, watch } from 'vue'
+
+import BehaviorItem from './components/behavior-item/index.vue'
+
+import { LISTEN_KEY } from '@/constants'
+import { useModelStore } from '@/stores/model'
+
+const modelValue = defineModel<boolean>()
+const modelStore = useModelStore()
+const value = ref<'motion' | 'expression'>('motion')
+
+watch(modelValue, () => {
+  value.value = 'motion'
+})
+
+function getMotionShortcutId(groupName: string, index: number) {
+  return `${modelStore.currentModel?.id}:motion:${groupName}:${index}`
+}
+
+function getExpressionShortcutId(index: number) {
+  return `${modelStore.currentModel?.id}:expression:${index}`
+}
+
+function playMotion(group: string, index: number) {
+  emit(LISTEN_KEY.PLAY_MOTION, { group, index })
+}
+
+function playExpression(index: number) {
+  emit(LISTEN_KEY.PLAY_EXPRESSION, index)
+}
+</script>
+
+<template>
+  <Modal
+    v-model:open="modelValue"
+    :cancel-text="false"
+    centered
+    :footer="null"
+    force-render
+    :title="$t('pages.preference.model.behaviorModal.title')"
+  >
+    <Segmented
+      v-model:value="value"
+      block
+      class="mb-4"
+      :options="[
+        { label: $t('pages.preference.model.behaviorModal.labels.motion'), value: 'motion' },
+        { label: $t('pages.preference.model.behaviorModal.labels.expression'), value: 'expression' },
+      ]"
+    />
+
+    <div
+      v-show="value === 'motion'"
+      class="flex flex-col gap-4"
+    >
+      <Empty
+        v-if="isEmpty(modelStore.currentMotions)"
+        :image="Empty.PRESENTED_IMAGE_SIMPLE"
+      />
+
+      <template v-else>
+        <div
+          v-for="([groupName, motions], groupIndex) in modelStore.currentMotions"
+          :key="groupName"
+        >
+          <div class="mb-2">
+            {{ $t('pages.preference.model.behaviorModal.labels.motionGroupIndex', { index: groupIndex + 1 }) }}
+          </div>
+
+          <List
+            bordered
+            :data-source="motions"
+            size="small"
+          >
+            <template #renderItem="{ index }">
+              <BehaviorItem
+                v-model="modelStore.shortcuts[getMotionShortcutId(groupName, index)]"
+                :label="$t('pages.preference.model.behaviorModal.labels.motionIndex', { index: index + 1 })"
+                @click="playMotion(groupName, index)"
+              />
+            </template>
+          </List>
+        </div>
+      </template>
+    </div>
+
+    <div
+      v-show="value === 'expression'"
+      class="flex flex-col"
+    >
+      <Empty
+        v-if="isEmpty(modelStore.currentExpressions)"
+        :image="Empty.PRESENTED_IMAGE_SIMPLE"
+      />
+
+      <List
+        v-else
+        bordered
+        :data-source="modelStore.currentExpressions"
+        size="small"
+      >
+        <template #renderItem="{ index }">
+          <BehaviorItem
+            v-model="modelStore.shortcuts[getExpressionShortcutId(index)]"
+            :label="$t('pages.preference.model.behaviorModal.labels.expressionIndex', { index: index + 1 })"
+            @click="playExpression(index)"
+          />
+        </template>
+      </List>
+    </div>
+  </Modal>
+</template>

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -11,6 +11,7 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { MasonryGrid, MasonryGridItem } from 'vue3-masonry-css'
 
+import BehaviorModal from './components/behavior-modal/index.vue'
 import FloatMenu from './components/float-menu/index.vue'
 import Upload from './components/upload/index.vue'
 
@@ -21,6 +22,7 @@ const modelStore = useModelStore()
 const firstItemRef = ref<HTMLElement>()
 const { height } = useElementSize(firstItemRef)
 const { t } = useI18n()
+const openBehaviorModal = ref(false)
 
 function setFirstItemRef(el: Element | ComponentPublicInstance | null, index: number) {
   if (!el || index > 0) return
@@ -68,6 +70,7 @@ async function handleDelete(item: Model) {
     >
       <Card
         :ref="(el) => setFirstItemRef(el, index)"
+        class="[&_[class^='i-']]:text-4"
         hoverable
         size="small"
         @click="modelStore.currentModel = item"
@@ -81,12 +84,18 @@ async function handleDelete(item: Model) {
 
         <template #actions>
           <i
-            class="i-iconamoon:check-circle-1-bold text-4"
+            class="i-lucide:circle-check"
             :class="{ 'text-success': item.id === modelStore.currentModel?.id }"
           />
 
           <i
-            class="i-iconamoon:link-external-bold text-4"
+            v-if="modelStore.currentModel?.id === item.id"
+            class="i-lucide:smile"
+            @click.stop="openBehaviorModal = true"
+          />
+
+          <i
+            class="i-lucide:folder-open"
             @click.stop="revealItemInDir(item.path)"
           />
 
@@ -98,7 +107,7 @@ async function handleDelete(item: Model) {
               @confirm="handleDelete(item)"
             >
               <i
-                class="i-iconamoon:trash-simple-bold text-4"
+                class="i-lucide:trash-2"
                 @click.stop
               />
             </Popconfirm>
@@ -109,4 +118,6 @@ async function handleDelete(item: Model) {
   </MasonryGrid>
 
   <FloatMenu />
+
+  <BehaviorModal v-model="openBehaviorModal" />
 </template>

--- a/src/pages/preference/components/shortcut/index.vue
+++ b/src/pages/preference/components/shortcut/index.vue
@@ -2,8 +2,9 @@
 import { storeToRefs } from 'pinia'
 
 import ProList from '@/components/pro-list/index.vue'
-import ProShortcut from '@/components/pro-shortcut/index.vue'
-import { useTauriShortcut } from '@/composables/useTauriShortcut'
+import ProListItem from '@/components/pro-list-item/index.vue'
+import Shortcut from '@/components/shortcut/index.vue'
+import { useKeyPress } from '@/composables/useKeyPress'
 import { toggleWindowVisible } from '@/plugins/window'
 import { useCatStore } from '@/stores/cat'
 import { useShortcutStore } from '@/stores/shortcut.ts'
@@ -12,57 +13,62 @@ const shortcutStore = useShortcutStore()
 const { visibleCat, visiblePreference, mirrorMode, penetrable, alwaysOnTop } = storeToRefs(shortcutStore)
 const catStore = useCatStore()
 
-useTauriShortcut(visibleCat, () => {
+useKeyPress(visibleCat, () => {
   catStore.window.visible = !catStore.window.visible
 })
 
-useTauriShortcut(visiblePreference, () => {
+useKeyPress(visiblePreference, () => {
   toggleWindowVisible('preference')
 })
 
-useTauriShortcut(mirrorMode, () => {
+useKeyPress(mirrorMode, () => {
   catStore.model.mirror = !catStore.model.mirror
 })
 
-useTauriShortcut(penetrable, () => {
+useKeyPress(penetrable, () => {
   catStore.window.passThrough = !catStore.window.passThrough
 })
 
-useTauriShortcut(alwaysOnTop, () => {
+useKeyPress(alwaysOnTop, () => {
   catStore.window.alwaysOnTop = !catStore.window.alwaysOnTop
 })
 </script>
 
 <template>
   <ProList :title="$t('pages.preference.shortcut.title')">
-    <ProShortcut
-      v-model="shortcutStore.visibleCat"
+    <ProListItem
       :description="$t('pages.preference.shortcut.hints.toggleCat')"
       :title="$t('pages.preference.shortcut.labels.toggleCat')"
-    />
+    >
+      <Shortcut v-model="shortcutStore.visibleCat" />
+    </ProListItem>
 
-    <ProShortcut
-      v-model="shortcutStore.visiblePreference"
+    <ProListItem
       :description="$t('pages.preference.shortcut.hints.togglePreferences')"
       :title="$t('pages.preference.shortcut.labels.togglePreferences')"
-    />
+    >
+      <Shortcut v-model="shortcutStore.visiblePreference" />
+    </ProListItem>
 
-    <ProShortcut
-      v-model="shortcutStore.mirrorMode"
+    <ProListItem
       :description="$t('pages.preference.shortcut.hints.mirrorMode')"
       :title="$t('pages.preference.shortcut.labels.mirrorMode')"
-    />
+    >
+      <Shortcut v-model="shortcutStore.mirrorMode" />
+    </ProListItem>
 
-    <ProShortcut
-      v-model="shortcutStore.penetrable"
+    <ProListItem
       :description="$t('pages.preference.shortcut.hints.passThrough')"
       :title="$t('pages.preference.shortcut.labels.passThrough')"
-    />
+    >
+      <Shortcut v-model="shortcutStore.penetrable" />
+    </ProListItem>
 
-    <ProShortcut
-      v-model="shortcutStore.alwaysOnTop"
+    <ProListItem
       :description="$t('pages.preference.shortcut.hints.alwaysOnTop')"
       :title="$t('pages.preference.shortcut.labels.alwaysOnTop')"
-    />
+    >
+      <Shortcut v-model="shortcutStore.alwaysOnTop" />
+    </ProListItem>
   </ProList>
 </template>

--- a/src/pages/preference/index.vue
+++ b/src/pages/preference/index.vue
@@ -23,9 +23,7 @@ const { t } = useI18n()
 const generalStore = useGeneralStore()
 const appWindow = getCurrentWebviewWindow()
 
-onMounted(async () => {
-  createTray()
-})
+onMounted(createTray)
 
 watch(() => generalStore.appearance.language, () => {
   appWindow.setTitle(t('pages.preference.title'))

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -1,3 +1,5 @@
+import type { CubismSpec } from 'pixi-live2d-display'
+
 import { resolveResource } from '@tauri-apps/api/path'
 import { filter, find } from 'es-toolkit/compat'
 import { nanoid } from 'nanoid'
@@ -15,30 +17,17 @@ export interface Model {
   isPreset: boolean
 }
 
-interface Motion {
-  Name: string
-  File: string
-  Sound?: string
-  FadeInTime: number
-  FadeOutTime: number
-  Description?: string
-}
-
-type MotionGroup = Record<string, Motion[]>
-
-interface Expression {
-  Name: string
-  File: string
-  Description?: string
-}
+export type Motions = Array<[string, CubismSpec.Motion[]]>
+export type Expressions = CubismSpec.Expression[]
 
 export const useModelStore = defineStore('model', () => {
   const models = ref<Model[]>([])
   const currentModel = ref<Model>()
-  const motions = ref<MotionGroup>({})
-  const expressions = ref<Expression[]>([])
   const supportKeys = reactive<Record<string, string>>({})
   const pressedKeys = reactive<Record<string, string>>({})
+  const currentMotions = ref<Motions>([])
+  const currentExpressions = ref<Expressions>([])
+  const shortcuts = reactive<Record<string, string>>({})
 
   const init = async () => {
     const modelsPath = await resolveResource('assets/models')
@@ -69,15 +58,11 @@ export const useModelStore = defineStore('model', () => {
   return {
     models,
     currentModel,
-    motions,
-    expressions,
     supportKeys,
     pressedKeys,
+    currentMotions,
+    currentExpressions,
+    shortcuts,
     init,
   }
-}, {
-  tauri: {
-    filterKeys: ['models', 'currentModel'],
-    filterKeysStrategy: 'pick',
-  },
 })

--- a/src/stores/model.ts
+++ b/src/stores/model.ts
@@ -17,16 +17,13 @@ export interface Model {
   isPreset: boolean
 }
 
-export type Motions = Array<[string, CubismSpec.Motion[]]>
-export type Expressions = CubismSpec.Expression[]
-
 export const useModelStore = defineStore('model', () => {
   const models = ref<Model[]>([])
   const currentModel = ref<Model>()
   const supportKeys = reactive<Record<string, string>>({})
   const pressedKeys = reactive<Record<string, string>>({})
-  const currentMotions = ref<Motions>([])
-  const currentExpressions = ref<Expressions>([])
+  const currentMotions = ref<Array<[string, CubismSpec.Motion[]]>>([])
+  const currentExpressions = ref<CubismSpec.Expression[]>([])
   const shortcuts = reactive<Record<string, string>>({})
 
   const init = async () => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -4,9 +4,9 @@ export function join(...paths: string[]) {
   const joinPaths = paths.map((path, index) => {
     if (index === 0) {
       return path.replace(new RegExp(`${sep()}+$`), '')
-    } else {
-      return path.replace(new RegExp(`^${sep()}+|${sep()}+$`, 'g'), '')
     }
+
+    return path.replace(new RegExp(`^${sep()}+|${sep()}+$`, 'g'), '')
   })
 
   return joinPaths.join(sep())


### PR DESCRIPTION
resolved #653

Users had no way to trigger Live2D model motions and expressions via keyboard shortcuts. This PR adds per-behavior shortcut binding, auto-assigns default shortcuts on model load, and wires up global shortcut registration so pressing a key combo plays the corresponding motion or expression in real time.

## Changes

- **Behavior modal** (`preference/model/behavior-modal`): New UI to view all motions and expressions grouped by type, with inline shortcut binding and a play button per entry
  - `BehaviorItem` component: binds a shortcut key (via `useKeyPress`) and emits a play click
- **`useKeyPress` composable** (renamed from `useTauriShortcut`): registers/unregisters Tauri global shortcuts reactively as the bound value changes
- **`useModel` composable**: on model load, auto-assigns default shortcuts (`Ctrl+1`…`Ctrl+0`, then `Ctrl+Shift+…`, `Ctrl+Alt+…`) to each motion/expression if not already set; exposes `getMotionShortcutId` / `getExpressionShortcutId` helpers
- **`model` store**: adds a `shortcuts` reactive map (`Record<string, string>`) persisted alongside other model settings
- **Main window**: listens for `PLAY_MOTION` / `PLAY_EXPRESSION` events emitted by the modal's play button and calls the Live2D API directly
- **Locales** (zh-CN, zh-TW, en-US, pt-BR, vi-VN): added keys for behavior modal title, segment labels, and indexed motion/expression labels
- **Icons**: switched from `@iconify-json/iconamoon` to `@iconify-json/lucide` for the play button icon