### PR TITLE
fix: improve Windows startup robustness for cold-start window state

### DIFF
--- a/src/composables/useModel.ts
+++ b/src/composables/useModel.ts
@@ -1,6 +1,6 @@
 import type { PhysicalPosition } from '@tauri-apps/api/dpi'
 
-import { LogicalSize } from '@tauri-apps/api/dpi'
+import { PhysicalSize } from '@tauri-apps/api/dpi'
 import { resolveResource, sep } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { message } from 'ant-design-vue'
@@ -18,6 +18,8 @@ import live2d from '../utils/live2d'
 const appWindow = getCurrentWebviewWindow()
 const digitKeys = '1234567890'.split('') as readonly string[]
 const letterKeys = 'QWERTYUIOPASDFGHJKLZXCVBNM'.split('') as readonly string[]
+let suppressScaleWriteback = false
+let hasCompletedInitialWindowSizeSync = false
 
 export interface ModelSize {
   width: number
@@ -65,11 +67,16 @@ export function useModel() {
     return `${modelId}:expression:${index}`
   }
 
-  async function handleLoad() {
+  async function handleLoad(
+    model = modelStore.currentModel,
+    options: { showError?: boolean } = {},
+  ) {
     try {
-      if (!modelStore.currentModel) return
+      if (!model) return false
 
-      const { path } = modelStore.currentModel
+      hasCompletedInitialWindowSizeSync = false
+
+      const { path } = model
 
       await resolveResource(path)
 
@@ -83,7 +90,7 @@ export function useModel() {
 
       handleResize()
 
-      const modelId = modelStore.currentModel.id
+      const modelId = model.id
 
       const behaviorIds: string[] = []
 
@@ -106,8 +113,15 @@ export function useModel() {
 
         modelStore.shortcuts[id] = shortcut
       }
+      return true
     } catch (error) {
-      message.error(String(error))
+      modelSize.value = void 0
+
+      if (options.showError ?? true) {
+        message.error(String(error))
+      }
+
+      return false
     }
   }
 
@@ -120,20 +134,52 @@ export function useModel() {
 
     live2d.resizeModel(modelSize.value)
 
-    const { width, height } = modelSize.value
-
-    if (round(innerWidth / innerHeight, 1) !== round(width / height, 1)) {
-      await appWindow.setSize(
-        new LogicalSize({
-          width: innerWidth,
-          height: Math.ceil(innerWidth * (height / width)),
-        }),
-      )
+    if (!hasCompletedInitialWindowSizeSync || suppressScaleWriteback) {
+      suppressScaleWriteback = false
+      return
     }
+
+    const { width } = modelSize.value
 
     const size = await appWindow.size()
 
     catStore.window.scale = round((size.width / width) * 100)
+  }
+
+  async function syncWindowSize() {
+    if (!modelSize.value) return false
+
+    const { width, height } = modelSize.value
+    const nextWidth = Math.round(width * (catStore.window.scale / 100))
+    const nextHeight = Math.round(height * (catStore.window.scale / 100))
+    const size = await appWindow.size()
+
+    if (size.width === nextWidth && size.height === nextHeight) {
+      hasCompletedInitialWindowSizeSync = true
+      return true
+    }
+
+    suppressScaleWriteback = true
+
+    try {
+      await appWindow.setSize(
+        new PhysicalSize({
+          width: nextWidth,
+          height: nextHeight,
+        }),
+      )
+
+      hasCompletedInitialWindowSizeSync = true
+
+      return true
+    } catch (error) {
+      suppressScaleWriteback = false
+      hasCompletedInitialWindowSizeSync = false
+
+      message.error(String(error))
+
+      return false
+    }
   }
 
   const handlePress = (key: string) => {
@@ -238,6 +284,7 @@ export function useModel() {
     handleLoad,
     handleDestroy,
     handleResize,
+    syncWindowSize,
     handleKeyChange,
     handleMouseChange,
     handleMouseMove,

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -2,7 +2,6 @@
 import type { MotionInfo } from 'easy-live2d'
 
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { PhysicalSize } from '@tauri-apps/api/dpi'
 import { Menu, PredefinedMenuItem } from '@tauri-apps/api/menu'
 import { sep } from '@tauri-apps/api/path'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
@@ -10,7 +9,7 @@ import { exists, readDir } from '@tauri-apps/plugin-fs'
 import { useDebounceFn, useEventListener } from '@vueuse/core'
 import { round } from 'es-toolkit'
 import { nth } from 'es-toolkit/compat'
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { useAppMenu } from '@/composables/useAppMenu'
 import { useDevice } from '@/composables/useDevice'
@@ -29,7 +28,7 @@ import { clearObject } from '@/utils/shared'
 
 const { startListening } = useDevice()
 const appWindow = getCurrentWebviewWindow()
-const { modelSize, handleLoad, handleDestroy, handleResize, handleKeyChange } = useModel()
+const { modelSize, handleLoad, handleDestroy, handleResize, syncWindowSize, handleKeyChange } = useModel()
 const catStore = useCatStore()
 const { getBaseMenu, getExitMenu } = useAppMenu()
 const modelStore = useModelStore()
@@ -37,8 +36,11 @@ const generalStore = useGeneralStore()
 const resizing = ref(false)
 const backgroundImagePath = ref<string>()
 const { stickActive } = useGamepad()
-
-onMounted(startListening)
+const isCanvasReady = ref(false)
+const INITIAL_MODEL_LOAD_RETRY_DELAY_MS = 100
+let loadedModelId: string | undefined
+let modelLoadVersion = 0
+let modelLoadBarrier = Promise.resolve()
 
 onUnmounted(handleDestroy)
 
@@ -54,49 +56,148 @@ useEventListener('resize', () => {
   debouncedResize()
 })
 
-watch(() => modelStore.currentModel, async (model) => {
-  if (!model) return
+function waitForAnimationFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
 
-  await handleLoad()
+function waitForDelay(delayMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs)
+  })
+}
 
-  const path = join(model.path, 'resources', 'background.png')
+async function ensureCanvasReady() {
+  await nextTick()
 
-  const existed = await exists(path)
+  let canvas = document.getElementById('live2dCanvas')
 
-  backgroundImagePath.value = existed ? convertFileSrc(path) : void 0
-
-  clearObject([modelStore.supportKeys, modelStore.pressedKeys])
-
-  const resourcePath = join(model.path, 'resources')
-  const groups = ['left-keys', 'right-keys']
-
-  for await (const groupName of groups) {
-    const groupDir = join(resourcePath, groupName)
-    const files = await readDir(groupDir).catch(() => [])
-    const imageFiles = files.filter(file => isImage(file.name))
-
-    for (const file of imageFiles) {
-      const fileName = file.name.split('.')[0]
-
-      modelStore.supportKeys[fileName] = join(groupDir, file.name)
-    }
+  if (!(canvas instanceof HTMLCanvasElement)) {
+    await waitForAnimationFrame()
+    canvas = document.getElementById('live2dCanvas')
   }
 
-  modelStore.modelReady = true
-}, { deep: true, immediate: true })
+  if (!(canvas instanceof HTMLCanvasElement)) {
+    throw new TypeError('[main] #live2dCanvas is not ready')
+  }
 
-watch([() => catStore.window.scale, modelSize], async ([scale, modelSize]) => {
-  if (!modelSize) return
+  isCanvasReady.value = true
+}
 
-  const { width, height } = modelSize
+async function loadCurrentModel(
+  model = modelStore.currentModel,
+  options: { retryOnFailure?: boolean } = {},
+) {
+  if (!model) return false
 
-  appWindow.setSize(
-    new PhysicalSize({
-      width: Math.round(width * (scale / 100)),
-      height: Math.round(height * (scale / 100)),
-    }),
-  )
-}, { immediate: true })
+  const version = ++modelLoadVersion
+  let completed = false
+  const previousLoad = modelLoadBarrier
+  let releaseCurrentLoad!: () => void
+  const currentLoad = new Promise<void>((resolve) => {
+    releaseCurrentLoad = resolve
+  })
+
+  modelLoadBarrier = currentLoad
+
+  await previousLoad
+
+  const isActiveLoad = () => {
+    return version === modelLoadVersion && modelStore.currentModel?.id === model.id
+  }
+
+  try {
+    if (!isActiveLoad()) {
+      return false
+    }
+
+    modelStore.modelReady = false
+
+    let didLoad = await handleLoad(model, { showError: !options.retryOnFailure })
+
+    if (!didLoad && options.retryOnFailure) {
+      await waitForDelay(INITIAL_MODEL_LOAD_RETRY_DELAY_MS)
+
+      if (!isActiveLoad()) {
+        return false
+      }
+
+      didLoad = await handleLoad(model)
+    }
+
+    if (!didLoad || !isActiveLoad()) {
+      return false
+    }
+
+    const didSyncWindowSize = await syncWindowSize()
+
+    if (!didSyncWindowSize) {
+      return false
+    }
+
+    if (!isActiveLoad()) {
+      return false
+    }
+
+    const path = join(model.path, 'resources', 'background.png')
+
+    const existed = await exists(path)
+
+    backgroundImagePath.value = existed ? convertFileSrc(path) : void 0
+
+    clearObject([modelStore.supportKeys, modelStore.pressedKeys])
+
+    const resourcePath = join(model.path, 'resources')
+    const groups = ['left-keys', 'right-keys']
+
+    for await (const groupName of groups) {
+      const groupDir = join(resourcePath, groupName)
+      const files = await readDir(groupDir).catch(() => [])
+      const imageFiles = files.filter(file => isImage(file.name))
+
+      for (const file of imageFiles) {
+        const fileName = file.name.split('.')[0]
+
+        modelStore.supportKeys[fileName] = join(groupDir, file.name)
+      }
+    }
+
+    if (!isActiveLoad()) {
+      return false
+    }
+
+    loadedModelId = model.id
+    modelStore.modelReady = true
+    completed = true
+
+    return true
+  } finally {
+    if (!completed && isActiveLoad()) {
+      modelStore.modelReady = true
+    }
+
+    releaseCurrentLoad()
+  }
+}
+
+onMounted(async () => {
+  startListening()
+  await ensureCanvasReady()
+  await loadCurrentModel(modelStore.currentModel, { retryOnFailure: true })
+})
+
+watch(() => modelStore.currentModel?.id, async (modelId) => {
+  if (!isCanvasReady.value || !modelId || modelId === loadedModelId) return
+
+  await loadCurrentModel()
+})
+
+watch(() => catStore.window.scale, async () => {
+  if (!modelSize.value) return
+
+  await syncWindowSize()
+})
 
 watch([modelStore.pressedKeys, stickActive], ([keys, stickActive]) => {
   const dirs = Object.values(keys).map((path) => {


### PR DESCRIPTION
## Summary
This is a candidate fix for a previously discussed Windows cold-start startup/window anomaly. The change aims to make startup window-state handling more robust, but I have not yet confirmed the original anomaly as definitively resolved across broader Windows environments.

## What changed
- Make the initial model load report explicit success or failure and avoid continuing startup initialization after a failed load.
- Move the initial load to the mounted/canvas-ready phase and serialize overlapping load attempts.
- Add an explicit initial window-size sync path so startup can reconcile model dimensions with the saved scale more predictably.
- Prevent the initial startup resize path from immediately writing an unsynchronized window size back into the saved scale.

## Validation
- Re-ran Windows conflict-state validation against an injected `app.windowState` value.
- In that scenario, the final settled window size did **not** stick to the injected conflict value.
- I was **not** able to reproduce the original startup anomaly in the latest validation pass.
- I did **not** observe any new regression in the tested startup behavior.
- Non-default scale restoration still needs broader validation; current automation does not fully prove that path.

## Notes
- Opening as a **draft** because this should still be treated as a candidate fix.
- I’d especially value confirmation from broader Windows testing, including cold-start and non-default scale scenarios.
- This PR is intentionally limited to startup load/state/initial size-sync behavior and does not include the separate mouse-performance changes from my self-use branch.