### PR TITLE
Feature/multi screen follow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5185,6 +5185,7 @@ dependencies = [
 name = "tauri-plugin-custom-window"
 version = "0.1.0"
 dependencies = [
+ "objc2-app-kit",
  "serde",
  "tauri",
  "tauri-nspanel",

--- a/src-tauri/src/plugins/window/Cargo.toml
+++ b/src-tauri/src/plugins/window/Cargo.toml
@@ -16,6 +16,7 @@ tauri-plugin.workspace = true
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel.workspace = true
+objc2-app-kit = "0.3"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 windows = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }

--- a/src-tauri/src/plugins/window/build.rs
+++ b/src-tauri/src/plugins/window/build.rs
@@ -3,6 +3,7 @@ const COMMANDS: &[&str] = &[
     "hide_window",
     "set_always_on_top",
     "set_taskbar_visibility",
+    "set_multi_screen_follow",
 ];
 
 fn main() {

--- a/src-tauri/src/plugins/window/permissions/default.toml
+++ b/src-tauri/src/plugins/window/permissions/default.toml
@@ -2,4 +2,4 @@
 
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-show-window", "allow-hide-window", "allow-set-always-on-top", "allow-set-taskbar-visibility"]
+permissions = ["allow-show-window", "allow-hide-window", "allow-set-always-on-top", "allow-set-taskbar-visibility", "allow-set-multi-screen-follow"]

--- a/src-tauri/src/plugins/window/src/commands/linux.rs
+++ b/src-tauri/src/plugins/window/src/commands/linux.rs
@@ -31,3 +31,12 @@ pub async fn set_always_on_top<R: Runtime>(
 pub async fn set_taskbar_visibility<R: Runtime>(window: WebviewWindow<R>, visible: bool) {
     let _ = window.set_skip_taskbar(!visible);
 }
+
+// 多屏跟随由前端统一控制，Linux 上窗口可自由跨屏，无需调整原生行为。
+#[command]
+pub async fn set_multi_screen_follow<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _window: WebviewWindow<R>,
+    _enabled: bool,
+) {
+}

--- a/src-tauri/src/plugins/window/src/commands/macos.rs
+++ b/src-tauri/src/plugins/window/src/commands/macos.rs
@@ -1,12 +1,49 @@
 #![allow(deprecated)]
 use crate::MAIN_WINDOW_LABEL;
+use objc2_app_kit::NSWindowCollectionBehavior;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{AppHandle, Runtime, WebviewWindow, command};
 use tauri_nspanel::{CollectionBehavior, ManagerExt, PanelLevel};
+
+// 多屏跟随开关；开启后去掉 `.stationary()`，让 NSPanel 可在不同屏幕之间移动。
+static MULTI_SCREEN_FOLLOW: AtomicBool = AtomicBool::new(false);
 
 enum MacOSPanelStatus {
     Show,
     Hide,
     SetAlwaysOnTop(bool),
+}
+
+fn show_collection_behavior() -> NSWindowCollectionBehavior {
+    let multi = MULTI_SCREEN_FOLLOW.load(Ordering::SeqCst);
+    if multi {
+        CollectionBehavior::new()
+            .can_join_all_spaces()
+            .full_screen_auxiliary()
+            .into()
+    } else {
+        CollectionBehavior::new()
+            .stationary()
+            .can_join_all_spaces()
+            .full_screen_auxiliary()
+            .into()
+    }
+}
+
+fn hide_collection_behavior() -> NSWindowCollectionBehavior {
+    let multi = MULTI_SCREEN_FOLLOW.load(Ordering::SeqCst);
+    if multi {
+        CollectionBehavior::new()
+            .move_to_active_space()
+            .full_screen_auxiliary()
+            .into()
+    } else {
+        CollectionBehavior::new()
+            .stationary()
+            .move_to_active_space()
+            .full_screen_auxiliary()
+            .into()
+    }
 }
 
 fn is_main_window<R: Runtime>(window: &WebviewWindow<R>) -> bool {
@@ -27,24 +64,12 @@ fn set_macos_panel<R: Runtime>(
                     MacOSPanelStatus::Show => {
                         panel.show();
 
-                        panel.set_collection_behavior(
-                            CollectionBehavior::new()
-                                .stationary()
-                                .can_join_all_spaces()
-                                .full_screen_auxiliary()
-                                .into(),
-                        );
+                        panel.set_collection_behavior(show_collection_behavior());
                     }
                     MacOSPanelStatus::Hide => {
                         panel.hide();
 
-                        panel.set_collection_behavior(
-                            CollectionBehavior::new()
-                                .stationary()
-                                .move_to_active_space()
-                                .full_screen_auxiliary()
-                                .into(),
-                        );
+                        panel.set_collection_behavior(hide_collection_behavior());
                     }
                     MacOSPanelStatus::SetAlwaysOnTop(always_on_top) => {
                         if always_on_top {
@@ -105,4 +130,25 @@ pub async fn set_always_on_top<R: Runtime>(
 #[command]
 pub async fn set_taskbar_visibility<R: Runtime>(app_handle: AppHandle<R>, visible: bool) {
     let _ = app_handle.set_dock_visibility(visible);
+}
+
+#[command]
+pub async fn set_multi_screen_follow<R: Runtime>(
+    app_handle: AppHandle<R>,
+    window: WebviewWindow<R>,
+    enabled: bool,
+) {
+    if !is_main_window(&window) {
+        return;
+    }
+
+    MULTI_SCREEN_FOLLOW.store(enabled, Ordering::SeqCst);
+
+    let app_handle_clone = app_handle.clone();
+
+    let _ = app_handle.run_on_main_thread(move || {
+        if let Ok(panel) = app_handle_clone.get_webview_panel(MAIN_WINDOW_LABEL) {
+            panel.set_collection_behavior(show_collection_behavior());
+        }
+    });
 }

--- a/src-tauri/src/plugins/window/src/commands/windows.rs
+++ b/src-tauri/src/plugins/window/src/commands/windows.rs
@@ -82,3 +82,12 @@ pub async fn set_always_on_top<R: Runtime>(
 pub async fn set_taskbar_visibility<R: Runtime>(window: WebviewWindow<R>, visible: bool) {
     let _ = window.set_skip_taskbar(!visible);
 }
+
+// 多屏跟随由前端统一控制，Windows 上窗口可自由跨屏，无需调整原生行为。
+#[command]
+pub async fn set_multi_screen_follow<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _window: WebviewWindow<R>,
+    _enabled: bool,
+) {
+}

--- a/src-tauri/src/plugins/window/src/lib.rs
+++ b/src-tauri/src/plugins/window/src/lib.rs
@@ -14,6 +14,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::hide_window,
             commands::set_always_on_top,
             commands::set_taskbar_visibility,
+            commands::set_multi_screen_follow,
         ])
         .build()
 }

--- a/src/composables/useMultiScreenFollow.ts
+++ b/src/composables/useMultiScreenFollow.ts
@@ -1,0 +1,83 @@
+import { PhysicalPosition } from '@tauri-apps/api/dpi'
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { cursorPosition, monitorFromPoint } from '@tauri-apps/api/window'
+import { useIntervalFn } from '@vueuse/core'
+import { watch } from 'vue'
+
+import { setMultiScreenFollow } from '@/plugins/window'
+import { useCatStore } from '@/stores/cat'
+import { useGeneralStore } from '@/stores/general'
+import { isMac } from '@/utils/platform'
+
+const POLL_INTERVAL_MS = 800
+
+export function useMultiScreenFollow() {
+  if (!isMac) return
+
+  const generalStore = useGeneralStore()
+  const catStore = useCatStore()
+  const appWindow = getCurrentWebviewWindow()
+
+  const tick = async () => {
+    if (!catStore.window.visible) return
+
+    const [winPos, winSize, cursor, scaleFactor] = await Promise.all([
+      appWindow.outerPosition(),
+      appWindow.outerSize(),
+      cursorPosition(),
+      appWindow.scaleFactor(),
+    ])
+
+    const cursorLogical = cursor.toLogical(scaleFactor)
+    const winCenterLogical = new PhysicalPosition(
+      winPos.x + Math.floor(winSize.width / 2),
+      winPos.y + Math.floor(winSize.height / 2),
+    ).toLogical(scaleFactor)
+
+    const [cursorMon, winMon] = await Promise.all([
+      monitorFromPoint(cursorLogical.x, cursorLogical.y),
+      monitorFromPoint(winCenterLogical.x, winCenterLogical.y),
+    ])
+
+    if (!cursorMon || !winMon) return
+
+    const sameMonitor
+      = winMon.position.x === cursorMon.position.x
+        && winMon.position.y === cursorMon.position.y
+        && winMon.size.width === cursorMon.size.width
+        && winMon.size.height === cursorMon.size.height
+
+    if (sameMonitor) return
+
+    const offsetX = winPos.x - winMon.position.x
+    const offsetY = winPos.y - winMon.position.y
+
+    const minX = cursorMon.position.x
+    const maxX = cursorMon.position.x + cursorMon.size.width - winSize.width
+    const minY = cursorMon.position.y
+    const maxY = cursorMon.position.y + cursorMon.size.height - winSize.height
+
+    const targetX = Math.max(minX, Math.min(cursorMon.position.x + offsetX, maxX))
+    const targetY = Math.max(minY, Math.min(cursorMon.position.y + offsetY, maxY))
+
+    if (targetX === winPos.x && targetY === winPos.y) return
+
+    await appWindow.setPosition(new PhysicalPosition(targetX, targetY))
+  }
+
+  const { pause, resume } = useIntervalFn(tick, POLL_INTERVAL_MS, { immediate: false })
+
+  watch(
+    () => generalStore.app.multiScreenFollow,
+    async (enabled) => {
+      await setMultiScreenFollow(enabled)
+
+      if (enabled) {
+        resume()
+      } else {
+        pause()
+      }
+    },
+    { immediate: true },
+  )
+}

--- a/src/composables/useMultiScreenFollow.ts
+++ b/src/composables/useMultiScreenFollow.ts
@@ -1,3 +1,5 @@
+import type { Monitor } from '@tauri-apps/api/window'
+
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { cursorPosition, monitorFromPoint } from '@tauri-apps/api/window'
@@ -11,12 +13,21 @@ import { isMac } from '@/utils/platform'
 
 const POLL_INTERVAL_MS = 800
 
+function monitorKey(mon: Monitor) {
+  return `${mon.position.x},${mon.position.y},${mon.size.width},${mon.size.height}`
+}
+
 export function useMultiScreenFollow() {
   if (!isMac) return
 
   const generalStore = useGeneralStore()
   const catStore = useCatStore()
   const appWindow = getCurrentWebviewWindow()
+
+  // 记忆每个屏幕上窗口最后停留的相对偏移（相对屏幕原点）。
+  // 大屏 → 小屏时偏移会被裁剪到小屏边界，若直接用这个被裁剪过的偏移再换算回大屏，
+  // 用户最初的位置就会丢失。缓存能在回到原屏幕时恢复用户实际设定的位置。
+  const monitorOffsets = new Map<string, { x: number, y: number }>()
 
   const tick = async () => {
     if (!catStore.window.visible) return
@@ -41,6 +52,12 @@ export function useMultiScreenFollow() {
 
     if (!cursorMon || !winMon) return
 
+    // 始终更新当前所在屏幕的偏移记忆，捕捉用户在屏内手动拖动后的最新位置。
+    monitorOffsets.set(monitorKey(winMon), {
+      x: winPos.x - winMon.position.x,
+      y: winPos.y - winMon.position.y,
+    })
+
     const sameMonitor
       = winMon.position.x === cursorMon.position.x
         && winMon.position.y === cursorMon.position.y
@@ -49,8 +66,10 @@ export function useMultiScreenFollow() {
 
     if (sameMonitor) return
 
-    const offsetX = winPos.x - winMon.position.x
-    const offsetY = winPos.y - winMon.position.y
+    // 优先使用目标屏幕的历史偏移；首次进入则沿用源屏幕的偏移作为初值。
+    const remembered = monitorOffsets.get(monitorKey(cursorMon))
+    const offsetX = remembered?.x ?? (winPos.x - winMon.position.x)
+    const offsetY = remembered?.y ?? (winPos.y - winMon.position.y)
 
     const minX = cursorMon.position.x
     const maxX = cursorMon.position.x + cursorMon.size.width - winSize.width
@@ -75,6 +94,7 @@ export function useMultiScreenFollow() {
       if (enabled) {
         resume()
       } else {
+        monitorOffsets.clear()
         pause()
       }
     },

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -50,6 +50,7 @@
           "launchOnStartup": "Launch on Startup",
           "showTaskbarIcon": "Show Taskbar Icon",
           "showTrayIcon": "Show Tray Icon",
+          "multiScreenFollow": "Follow Active Display",
           "appearanceSettings": "Appearance Settings",
           "themeMode": "Theme Mode",
           "language": "Language",
@@ -66,6 +67,7 @@
         "hints": {
           "showTaskbarIcon": "When enabled, the window can be captured via OBS Studio.",
           "showTrayIcon": "When enabled, the app icon is displayed in the system tray.",
+          "multiScreenFollow": "When enabled, the cat automatically moves to whichever display the cursor is on.",
           "inputMonitoringPermission": "Enable input monitoring to receive keyboard and mouse events from the system.",
           "inputMonitoringPermissionGuide": "If the permission is already enabled, select it and click the \"-\" button to remove it, then manually add it again and restart the app."
         },

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -50,6 +50,7 @@
           "launchOnStartup": "Iniciar na inicialização",
           "showTaskbarIcon": "Mostrar ícone na barra de tarefas",
           "showTrayIcon": "Mostrar ícone na bandeja",
+          "multiScreenFollow": "Seguir o monitor ativo",
           "appearanceSettings": "Configurações de aparência",
           "themeMode": "Tema",
           "language": "Idiomas",
@@ -66,6 +67,7 @@
         "hints": {
           "showTaskbarIcon": "Uma vez ativado, você pode capturar a janela via OBS Studio.",
           "showTrayIcon": "Quando ativado, o ícone do aplicativo é exibido na bandeja do sistema.",
+          "multiScreenFollow": "Quando ativado, o BongoCat se move automaticamente para o monitor onde está o cursor.",
           "inputMonitoringPermission": "Ative a permissão de monitoramento de entrada para receber eventos de teclado e mouse do sistema para responder às suas ações.",
           "inputMonitoringPermissionGuide": "Se a permissão já estiver ativada, primeiro selecione-a e clique no botão \"-\" para removê-la. Em seguida, adicione-a novamente manualmente e reinicie o aplicativo para garantir que a permissão entre em vigor."
         },

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -50,6 +50,7 @@
           "launchOnStartup": "Khởi động cùng hệ thống",
           "showTaskbarIcon": "Hiện biểu tượng trên thanh tác vụ (icon taskbar)",
           "showTrayIcon": "Hiện biểu tượng trên khay hệ thống (tray)",
+          "multiScreenFollow": "Theo màn hình hiện tại",
           "appearanceSettings": "Cài đặt giao diện",
           "themeMode": "Giao diện",
           "language": "Ngôn ngữ",
@@ -66,6 +67,7 @@
         "hints": {
           "showTaskbarIcon": "Bật để có thể quay cửa sổ qua OBS.",
           "showTrayIcon": "Bật để hiện biểu tượng ứng dụng trên khay hệ thống.",
+          "multiScreenFollow": "Khi bật, BongoCat sẽ tự động di chuyển sang màn hình đang đặt con trỏ chuột.",
           "inputMonitoringPermission": "Bật quyền giám sát để nhận sự kiện bàn phím và chuột từ hệ thống nhằm phản hồi thao tác của bạn.",
           "inputMonitoringPermissionGuide": "Nếu quyền đã được bật, hãy chọn nó và nhấn nút \"-\" để xóa. Sau đó thêm lại thủ công và khởi động lại ứng dụng để đảm bảo quyền được áp dụng."
         },

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -50,6 +50,7 @@
           "launchOnStartup": "开机自启动",
           "showTaskbarIcon": "显示任务栏图标",
           "showTrayIcon": "显示托盘图标",
+          "multiScreenFollow": "跟随当前屏幕",
           "appearanceSettings": "外观设置",
           "themeMode": "主题模式",
           "language": "语言",
@@ -66,6 +67,7 @@
         "hints": {
           "showTaskbarIcon": "启用后，即可通过 OBS Studio 捕获窗口。",
           "showTrayIcon": "启用后，在系统托盘中显示应用图标。",
+          "multiScreenFollow": "启用后，BongoCat 会自动移动到鼠标所在的显示器。",
           "inputMonitoringPermission": "开启输入监控权限，以便接收系统的键盘和鼠标事件来响应你的操作。",
           "inputMonitoringPermissionGuide": "如果权限已开启，请先选中并点击“-”按钮将其删除，然后重新手动添加，最后重启应用以确保权限生效。"
         },

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -50,6 +50,7 @@
           "launchOnStartup": "開機自動啟動",
           "showTaskbarIcon": "顯示工作列圖示",
           "showTrayIcon": "顯示托盤圖示",
+          "multiScreenFollow": "跟隨目前螢幕",
           "appearanceSettings": "外觀設定",
           "themeMode": "主題模式",
           "language": "語言",
@@ -66,6 +67,7 @@
         "hints": {
           "showTaskbarIcon": "啟用後，即可透過 OBS Studio 擷取視窗。",
           "showTrayIcon": "啟用後，在系統托盤中顯示應用程式圖示。",
+          "multiScreenFollow": "啟用後，BongoCat 會自動移動到滑鼠所在的螢幕。",
           "inputMonitoringPermission": "開啟輸入監控權限，以便接收系統的鍵盤和滑鼠游標事件來回應您的操作。",
           "inputMonitoringPermissionGuide": "如果權限已開啟，請先選中並點擊「-」按鈕將其刪除，然後重新手動新增，最後重啟應用程式以確保權限生效。"
         },

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -16,6 +16,7 @@ import { useAppMenu } from '@/composables/useAppMenu'
 import { useDevice } from '@/composables/useDevice'
 import { useGamepad } from '@/composables/useGamepad'
 import { useModel } from '@/composables/useModel'
+import { useMultiScreenFollow } from '@/composables/useMultiScreenFollow'
 import { useTauriListen } from '@/composables/useTauriListen'
 import { LISTEN_KEY } from '@/constants'
 import { hideWindow, setAlwaysOnTop, setTaskbarVisibility, showWindow } from '@/plugins/window'
@@ -38,6 +39,8 @@ const generalStore = useGeneralStore()
 const resizing = ref(false)
 const backgroundImagePath = ref<string>()
 const { stickActive } = useGamepad()
+
+useMultiScreenFollow()
 
 onMounted(startListening)
 

--- a/src/pages/preference/components/general/index.vue
+++ b/src/pages/preference/components/general/index.vue
@@ -6,6 +6,7 @@ import { watch } from 'vue'
 import ProListItem from '@/components/pro-list-item/index.vue'
 import ProList from '@/components/pro-list/index.vue'
 import { useGeneralStore } from '@/stores/general'
+import { isMac } from '@/utils/platform'
 
 import MacosPermissions from './components/macos-permissions/index.vue'
 import ThemeMode from './components/theme-mode/index.vue'
@@ -45,6 +46,14 @@ watch(() => generalStore.app.autostart, async (value) => {
       :title="$t('pages.preference.general.labels.showTrayIcon')"
     >
       <Switch v-model:checked="generalStore.app.trayVisible" />
+    </ProListItem>
+
+    <ProListItem
+      v-if="isMac"
+      :description="$t('pages.preference.general.hints.multiScreenFollow')"
+      :title="$t('pages.preference.general.labels.multiScreenFollow')"
+    >
+      <Switch v-model:checked="generalStore.app.multiScreenFollow" />
     </ProListItem>
   </ProList>
 

--- a/src/plugins/window.ts
+++ b/src/plugins/window.ts
@@ -13,6 +13,7 @@ const COMMAND = {
   HIDE_WINDOW: 'plugin:custom-window|hide_window',
   SET_ALWAYS_ON_TOP: 'plugin:custom-window|set_always_on_top',
   SET_TASKBAR_VISIBILITY: 'plugin:custom-window|set_taskbar_visibility',
+  SET_MULTI_SCREEN_FOLLOW: 'plugin:custom-window|set_multi_screen_follow',
 }
 
 export function showWindow(label?: WindowLabel) {
@@ -51,4 +52,8 @@ export async function toggleWindowVisible(label?: WindowLabel) {
 
 export async function setTaskbarVisibility(visible: boolean) {
   invoke(COMMAND.SET_TASKBAR_VISIBILITY, { visible })
+}
+
+export function setMultiScreenFollow(enabled: boolean) {
+  return invoke(COMMAND.SET_MULTI_SCREEN_FOLLOW, { enabled })
 }

--- a/src/stores/general.ts
+++ b/src/stores/general.ts
@@ -13,6 +13,7 @@ export interface GeneralStore {
     autostart: boolean
     taskbarVisible: boolean
     trayVisible: boolean
+    multiScreenFollow: boolean
   }
   appearance: {
     theme: 'auto' | Theme
@@ -49,6 +50,7 @@ export const useGeneralStore = defineStore('general', () => {
     autostart: false,
     taskbarVisible: false,
     trayVisible: true,
+    multiScreenFollow: false,
   })
 
   const appearance = reactive<GeneralStore['appearance']>({


### PR DESCRIPTION
## Summary

macOS 主窗口由 NSPanel 创建，`CollectionBehavior` 含 `.stationary()`，导致面板被钉死在创建时所在屏幕，多显示器用户无法把猫咪带到当前工作的屏幕。

本 PR 在「偏好设置 → 通用 → 应用设置」新增「跟随当前屏幕」开关（仅 macOS 显示，默认关闭，行为保持现状）。开启后，BongoCat 会自动跟随鼠标所在显示器，并按相对偏移落位、记忆每屏位置。

## 变更要点

### macOS 行为
- Rust 端新增 `set_multi_screen_follow` command，使用 `AtomicBool` 共享开关状态，`show` / `hide` 路径同步读取
- 开启时去掉 `.stationary()` 让 NSPanel 可跨 Space / 屏幕

### 前端跟随逻辑
- 新增 `useMultiScreenFollow` composable，开关启用时以 800ms 间隔轮询 `cursorPosition` + `monitorFromPoint`
- 按相对偏移把窗口平移到鼠标所在显示器，并裁剪到屏幕边界
- 引入 `monitorOffsets` Map（key = `x,y,w,h`），记忆每个屏幕上窗口的最近停留位置：
  - 每次轮询同步当前屏幕的最新偏移，捕获用户屏内手动拖动
  - 跨屏移动时优先使用目标屏幕的历史偏移，无记录再用源屏偏移作为初值
  - 关闭开关时清空 Map，避免状态残留
- **解决的问题**：大屏 → 小屏切换时偏移会被裁剪到小屏边界，若不缓存原始位置，回到大屏后用户最初手动设定的位置会永久丢失

### 跨平台
- Windows / Linux 端提供同名 no-op，保持 `generate_handler!` 跨平台符号一致

### 国际化
- 5 个 locale (en-US / zh-CN / zh-TW / pt-BR / vi-VN) 全量补齐文案

## Test plan

- [x] macOS：偏好设置 → 通用 → 应用设置，确认「跟随当前屏幕」开关存在且默认关闭
- [x] 关闭状态下 NSPanel 行为与现状一致（钉在创建时屏幕）
- [x] 开启状态下，鼠标移到另一台显示器，BongoCat 在 < 1s 内跟随过来
- [x] 在大屏靠右下手动拖动 BongoCat 到 (X, Y) → 移到小屏 → 再回大屏，BongoCat 回到 (X, Y)
- [x] 多次跨屏切换无累计漂移，窗口始终被裁剪在目标屏幕内