### PR TITLE
feat: add Windows raw input pointer tracking fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tauri-plugin = { version = "2", features = [ "build" ] }
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2.1" }
 tauri-plugin-custom-window = { path = "./src-tauri/src/plugins/window" }
 tauri-plugin-admin-status = { path = "./src-tauri/src/plugins/admin-status" }
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_UI_Input", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,5 +45,8 @@ gilrs = { git = "https://github.com/ayangweb/gilrs", default-features = false, f
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel.workspace = true
 
+[target."cfg(target_os = \"windows\")".dependencies]
+windows.workspace = true
+
 [features]
 cargo-clippy = []

--- a/src-tauri/src/core/device.rs
+++ b/src-tauri/src/core/device.rs
@@ -9,6 +9,7 @@ pub enum DeviceEventKind {
     MousePress,
     MouseRelease,
     MouseMove,
+    MouseMoveDelta,
     KeyboardPress,
     KeyboardRelease,
 }
@@ -20,6 +21,14 @@ pub struct DeviceEvent {
 }
 
 static IS_LISTENING: AtomicBool = AtomicBool::new(false);
+
+pub fn emit_device_event<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    kind: DeviceEventKind,
+    value: Value,
+) {
+    let _ = app_handle.emit("device-changed", DeviceEvent { kind, value });
+}
 
 #[command]
 pub async fn start_device_listening<R: Runtime>(app_handle: AppHandle<R>) -> Result<(), String> {
@@ -54,7 +63,7 @@ pub async fn start_device_listening<R: Runtime>(app_handle: AppHandle<R>) -> Res
             _ => return,
         };
 
-        let _ = app_handle.emit("device-changed", device_event);
+        emit_device_event(&app_handle, device_event.kind, device_event.value);
     };
 
     listen(callback).map_err(|err| format!("Failed to listen device: {:?}", err))?;

--- a/src-tauri/src/core/setup/mod.rs
+++ b/src-tauri/src/core/setup/mod.rs
@@ -3,14 +3,20 @@ use tauri::{AppHandle, WebviewWindow};
 #[cfg(target_os = "macos")]
 mod macos;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 pub mod common;
+
+#[cfg(target_os = "windows")]
+mod windows;
 
 #[cfg(target_os = "macos")]
 pub use macos::*;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 pub use common::*;
+
+#[cfg(target_os = "windows")]
+pub use windows::*;
 
 pub fn default(
     app_handle: &AppHandle,

--- a/src-tauri/src/core/setup/windows.rs
+++ b/src-tauri/src/core/setup/windows.rs
@@ -1,0 +1,130 @@
+use crate::core::device::{DeviceEventKind, emit_device_event};
+use std::mem::{size_of, zeroed};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+use tauri::{AppHandle, WebviewWindow};
+use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+use windows::Win32::UI::Input::{
+    GetRawInputData, HRAWINPUT, MOUSE_MOVE_ABSOLUTE, RAW_INPUT_DATA_COMMAND_FLAGS, RAWINPUT,
+    RAWINPUTDEVICE, RAWINPUTHEADER, RID_INPUT, RIDEV_INPUTSINK, RIM_TYPEMOUSE,
+    RegisterRawInputDevices,
+};
+use windows::Win32::UI::WindowsAndMessaging::{
+    CallWindowProcW, DefWindowProcW, GWLP_WNDPROC, SetWindowLongPtrW, WM_INPUT, WNDPROC,
+};
+
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+static ORIGINAL_WND_PROC: AtomicIsize = AtomicIsize::new(0);
+static RAW_INPUT_INSTALLED: AtomicBool = AtomicBool::new(false);
+
+pub fn platform(
+    app_handle: &AppHandle,
+    main_window: WebviewWindow,
+    _preference_window: WebviewWindow,
+) {
+    if RAW_INPUT_INSTALLED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    let _ = APP_HANDLE.set(app_handle.clone());
+
+    let Ok(hwnd) = main_window.hwnd() else {
+        RAW_INPUT_INSTALLED.store(false, Ordering::SeqCst);
+        return;
+    };
+
+    unsafe {
+        if register_raw_mouse(hwnd).is_err() {
+            RAW_INPUT_INSTALLED.store(false, Ordering::SeqCst);
+            return;
+        }
+
+        let previous =
+            SetWindowLongPtrW(hwnd, GWLP_WNDPROC, raw_input_wnd_proc as *const () as isize);
+
+        if previous == 0 {
+            RAW_INPUT_INSTALLED.store(false, Ordering::SeqCst);
+            return;
+        }
+
+        ORIGINAL_WND_PROC.store(previous, Ordering::SeqCst);
+    }
+}
+
+unsafe fn register_raw_mouse(hwnd: HWND) -> windows::core::Result<()> {
+    let devices = [RAWINPUTDEVICE {
+        usUsagePage: 0x01,
+        usUsage: 0x02,
+        dwFlags: RIDEV_INPUTSINK,
+        hwndTarget: hwnd,
+    }];
+
+    unsafe { RegisterRawInputDevices(&devices, size_of::<RAWINPUTDEVICE>() as u32) }
+}
+
+unsafe extern "system" fn raw_input_wnd_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    if msg == WM_INPUT {
+        if let Some((x, y)) = unsafe { read_mouse_delta(lparam) } {
+            if let Some(app_handle) = APP_HANDLE.get() {
+                emit_device_event(
+                    app_handle,
+                    DeviceEventKind::MouseMoveDelta,
+                    serde_json::json!({ "x": x, "y": y }),
+                );
+            }
+        }
+
+        return unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) };
+    }
+
+    unsafe { call_original_wnd_proc(hwnd, msg, wparam, lparam) }
+}
+
+unsafe fn call_original_wnd_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    let previous = ORIGINAL_WND_PROC.load(Ordering::SeqCst);
+
+    if previous == 0 {
+        return unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) };
+    }
+
+    let previous_proc: WNDPROC = Some(unsafe { std::mem::transmute(previous) });
+
+    unsafe { CallWindowProcW(previous_proc, hwnd, msg, wparam, lparam) }
+}
+
+unsafe fn read_mouse_delta(lparam: LPARAM) -> Option<(i32, i32)> {
+    let mut raw_input: RAWINPUT = unsafe { zeroed() };
+    let mut raw_input_size = size_of::<RAWINPUT>() as u32;
+    let header_size = size_of::<RAWINPUTHEADER>() as u32;
+
+    let status = unsafe {
+        GetRawInputData(
+            HRAWINPUT(lparam.0 as *mut _),
+            RAW_INPUT_DATA_COMMAND_FLAGS(RID_INPUT.0),
+            Some(&mut raw_input as *mut _ as *mut _),
+            &mut raw_input_size,
+            header_size,
+        )
+    };
+
+    if status == u32::MAX || status == 0 || raw_input.header.dwType != RIM_TYPEMOUSE.0 {
+        return None;
+    }
+
+    let mouse = unsafe { raw_input.data.mouse };
+
+    if mouse.usFlags.0 & MOUSE_MOVE_ABSOLUTE.0 != 0 {
+        return None;
+    }
+
+    if mouse.lLastX == 0 && mouse.lLastY == 0 {
+        return None;
+    }
+
+    Some((mouse.lLastX, mouse.lLastY))
+}

--- a/src/composables/useDevice.ts
+++ b/src/composables/useDevice.ts
@@ -1,6 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { PhysicalPosition } from '@tauri-apps/api/dpi'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { cursorPosition } from '@tauri-apps/api/window'
 import { isNil } from 'es-toolkit'
 import { Ticker } from 'pixi.js'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
@@ -9,6 +10,7 @@ import { useAppStore } from '@/stores/app'
 import { useCatStore } from '@/stores/cat'
 import { useModelStore } from '@/stores/model'
 import { inBetween } from '@/utils/is'
+import { getCursorMonitor } from '@/utils/monitor'
 import { isMac, isWindows } from '@/utils/platform'
 
 import { INVOKE_KEY, LISTEN_KEY, WINDOW_LABEL } from '../constants'
@@ -30,12 +32,17 @@ interface MouseMoveEvent {
   value: CursorPoint
 }
 
+interface MouseMoveDeltaEvent {
+  kind: 'MouseMoveDelta'
+  value: CursorPoint
+}
+
 interface KeyboardEvent {
   kind: 'KeyboardPress' | 'KeyboardRelease'
   value: string
 }
 
-type DeviceEvent = MouseButtonEvent | MouseMoveEvent | KeyboardEvent
+type DeviceEvent = MouseButtonEvent | MouseMoveEvent | MouseMoveDeltaEvent | KeyboardEvent
 
 const DAMPING_DECAY = 0.75
 const appWindow = getCurrentWebviewWindow()
@@ -46,7 +53,9 @@ export function useDevice() {
   const appStore = useAppStore()
   const catStore = useCatStore()
   const latestCursorPoint = ref<CursorPoint>()
+  const rawCursorPoint = ref<CursorPoint>()
   const smoothedCursorPoint = ref<CursorPoint>()
+  const lastAbsoluteMouseMoveAt = ref(0)
   const scaleFactor = ref(1)
   const { handlePress, handleRelease, handleMouseChange, handleMouseMove } = useModel()
 
@@ -77,6 +86,8 @@ export function useDevice() {
 
   onMounted(async () => {
     scaleFactor.value = isMac ? await appWindow.scaleFactor() : 1
+    const cursor = await cursorPosition()
+    rawCursorPoint.value = { x: cursor.x, y: cursor.y }
 
     appWindow.onScaleChanged(({ payload }) => {
       if (!isMac) return
@@ -167,6 +178,31 @@ export function useDevice() {
     onHideOnHover(x, y)
   }
 
+  const handleRawMouseMove = async (delta: CursorPoint) => {
+    if (Date.now() - lastAbsoluteMouseMoveAt.value < 32) return
+
+    let base = rawCursorPoint.value ?? latestCursorPoint.value
+
+    if (!base) {
+      const cursor = await cursorPosition()
+
+      base = { x: cursor.x, y: cursor.y }
+    }
+
+    const monitor = await getCursorMonitor(new PhysicalPosition(base.x, base.y))
+
+    if (!monitor) return
+
+    const { position, size } = monitor
+    const next = {
+      x: Math.max(position.x, Math.min(base.x + delta.x, position.x + size.width)),
+      y: Math.max(position.y, Math.min(base.y + delta.y, position.y + size.height)),
+    }
+
+    rawCursorPoint.value = next
+    latestCursorPoint.value = next
+  }
+
   const handleAutoRelease = (key: string, delay = 100) => {
     handlePress(key)
 
@@ -214,7 +250,11 @@ export function useDevice() {
       case 'MouseRelease':
         return handleMouseChange(value, false)
       case 'MouseMove':
+        lastAbsoluteMouseMoveAt.value = Date.now()
+        rawCursorPoint.value = value
         return latestCursorPoint.value = value
+      case 'MouseMoveDelta':
+        return void handleRawMouseMove(value)
     }
   })
 


### PR DESCRIPTION
## Summary
- register a Windows raw input hook for the main window
- emit mouse delta events when absolute cursor positions are unavailable
- blend relative pointer deltas into the existing cursor-follow pipeline as a fallback path

## Validation
- cargo check
- node_modules\\.bin\\tsc.cmd --noEmit