### PR TITLE
fix: make BongoCat visible on all macOS desktops/spaces

### DIFF
--- a/src-tauri/src/core/setup/macos.rs
+++ b/src-tauri/src/core/setup/macos.rs
@@ -43,7 +43,7 @@ pub fn platform(
     panel.set_collection_behavior(
         CollectionBehavior::new()
             .stationary()
-            .move_to_active_space()
+            .can_join_all_spaces()
             .full_screen_auxiliary()
             .into(),
     );


### PR DESCRIPTION
Fix macOS display issue #966 