### PR TITLE
fix: keep custom model state consistent with disk

### DIFF
--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -59,6 +59,12 @@ async function handleUpload() {
 watch(selectPaths, async (paths) => {
   for await (const fromPath of paths) {
     try {
+      const entries = await readDir(fromPath)
+
+      if (!entries.some(entry => entry.isFile && entry.name.endsWith('.model3.json'))) {
+        throw new Error(t('utils.live2d.hints.notFound'))
+      }
+
       const id = nanoid()
 
       let mode: ModelMode = 'standard'

--- a/src/pages/preference/components/model/index.vue
+++ b/src/pages/preference/components/model/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { remove } from '@tauri-apps/plugin-fs'
+import { exists, remove } from '@tauri-apps/plugin-fs'
 import { revealItemInDir } from '@tauri-apps/plugin-opener'
 import { useElementSize } from '@vueuse/core'
 import { Card, Masonry, message, Popconfirm } from 'antdv-next'
@@ -47,17 +47,19 @@ async function handleDelete(item: Model) {
   const { id, path } = item
 
   try {
-    await remove(path, { recursive: true })
+    if (await exists(path)) {
+      await remove(path, { recursive: true })
+    }
 
-    message.success(t('pages.preference.model.hints.deleteSuccess'))
-  } catch (error) {
-    message.error(String(error))
-  } finally {
     modelStore.models = modelStore.models.filter(item => item.id !== id)
 
     if (id === modelStore.currentModel?.id) {
       modelStore.currentModel = modelStore.models[0]
     }
+
+    message.success(t('pages.preference.model.hints.deleteSuccess'))
+  } catch (error) {
+    message.error(String(error))
   }
 }
 </script>


### PR DESCRIPTION
## Summary

- reject custom model folders without a root Live2D model descriptor before copying or persisting them
- remove stale model records when their backing directory is already missing
- keep the saved model list and current selection intact when filesystem deletion fails

## Root cause

The importer treated a successful directory copy as a valid model import, while the loader requires a root `*.model3.json` file. The delete path updated Pinia state from `finally`, so it discarded the model record after both successful and failed filesystem operations.

## Checks

- `eslint src`
- `tsc --noEmit`
- `vite build`
