### PR TITLE
feat: 新增窗口位置自动镜像功能

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,5 +55,12 @@
 
   "i18n-ally.localesPaths": ["src/locales"],
   "i18n-ally.keystyle": "nested",
-  "i18n-ally.displayLanguage": "zh-CN"
+  "i18n-ally.displayLanguage": "zh-CN",
+  "python-envs.pythonProjects": [
+    {
+      "path": "src-tauri/src/core",
+      "envManager": "ms-python.python:venv",
+      "packageManager": "ms-python.python:pip"
+    }
+  ]
 }

--- a/src/composables/useAutoMirror.ts
+++ b/src/composables/useAutoMirror.ts
@@ -1,0 +1,52 @@
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { availableMonitors } from '@tauri-apps/api/window'
+import { onMounted, onUnmounted } from 'vue'
+
+import { useCatStore } from '@/stores/cat'
+
+const appWindow = getCurrentWebviewWindow()
+
+export function useAutoMirror() {
+  const catStore = useCatStore()
+  let unlisten: (() => void) | null = null
+
+  onMounted(async () => {
+    unlisten = await appWindow.onMoved(updateMirrorByPosition)
+
+    if (catStore.model.autoMirror) {
+      await updateMirrorByPosition()
+    }
+  })
+
+  onUnmounted(() => {
+    unlisten?.()
+  })
+
+  async function updateMirrorByPosition() {
+    if (!catStore.model.autoMirror) return
+
+    try {
+      const windowPos = await appWindow.outerPosition()
+      const windowSize = await appWindow.outerSize()
+      const monitors = await availableMonitors()
+
+      const windowCenterX = windowPos.x + windowSize.width / 2
+      const windowCenterY = windowPos.y + windowSize.height / 2
+
+      const monitor = monitors.find(m =>
+        windowCenterX >= m.position.x
+        && windowCenterX < m.position.x + m.size.width
+        && windowCenterY >= m.position.y
+        && windowCenterY < m.position.y + m.size.height,
+      )
+
+      if (!monitor) return
+
+      const monitorCenterX = monitor.position.x + monitor.size.width / 2
+
+      catStore.model.mirror = windowCenterX < monitorCenterX
+    } catch {
+      // Silently ignore — non-critical feature
+    }
+  }
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -13,6 +13,7 @@
         "labels": {
           "modelSettings": "Model Settings",
           "mirrorMode": "Mirror Mode",
+          "autoMirror": "Auto Mirror",
           "mouseMirror": "Mouse Mirror",
           "ignoreMouse": "Ignore Mouse Events",
           "windowSettings": "Window Settings",
@@ -30,6 +31,7 @@
         },
         "hints": {
           "mirrorMode": "When enabled, the model will be mirrored horizontally.",
+          "autoMirror": "When enabled, the model will mirror automatically based on which side of the screen the window is on.",
           "mouseMirror": "When enabled, the mouse will mirror the hand movement.",
           "ignoreMouse": "When enabled, the model will not respond to mouse events. Useful for keyboard mode or gamepad mode.",
           "motionSound": "When enabled, the model will play corresponding sound effects when performing actions (if they exist).",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -13,6 +13,7 @@
         "labels": {
           "modelSettings": "Configurações do Modelo",
           "mirrorMode": "Modo Espelho",
+          "autoMirror": "Espelho Automático",
           "mouseMirror": "Espelho do Mouse",
           "ignoreMouse": "Ignorar Eventos do Mouse",
           "windowSettings": "Configurações da Janela",
@@ -30,6 +31,7 @@
         },
         "hints": {
           "mirrorMode": "Quando ativado, o modelo será invertido horizontalmente.",
+          "autoMirror": "Quando ativado, o modelo será invertido automaticamente com base no lado da tela em que a janela está.",
           "mouseMirror": "Quando ativado, o mouse espelhará o movimento da mão.",
           "ignoreMouse": "Quando ativado, o modelo não responderá a eventos do mouse. Útil para o modo teclado ou modo controle.",
           "motionSound": "Quando ativado, o modelo reproduzirá efeitos sonoros correspondentes ao executar ações (se existirem).",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -13,6 +13,7 @@
         "labels": {
           "modelSettings": "Cài đặt Mô hình",
           "mirrorMode": "Chế độ gương",
+          "autoMirror": "Tự động gương",
           "mouseMirror": "Phản chiếu chuột",
           "ignoreMouse": "Bỏ qua sự kiện chuột",
           "windowSettings": "Cài đặt Cửa sổ",
@@ -30,6 +31,7 @@
         },
         "hints": {
           "mirrorMode": "Bật để lật ngang mô hình.",
+          "autoMirror": "Khi bật, mô hình sẽ tự động phản chiếu dựa trên vị trí cửa sổ ở bên trái hay bên phải màn hình.",
           "mouseMirror": "Khi bật, chuột của mô hình sẽ phản chiếu theo chuyển động chuột thực tế.",
           "ignoreMouse": "Khi bật, mô hình sẽ không phản hồi sự kiện chuột. Hữu ích cho chế độ bàn phím hoặc chế độ tay cầm.",
           "motionSound": "Khi bật, mô hình sẽ phát các âm thanh tương ứng khi thực hiện hành động (nếu tồn tại).",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -13,6 +13,7 @@
         "labels": {
           "modelSettings": "模型设置",
           "mirrorMode": "镜像模式",
+          "autoMirror": "自动镜像",
           "mouseMirror": "鼠标镜像",
           "ignoreMouse": "忽略鼠标事件",
           "windowSettings": "窗口设置",
@@ -30,6 +31,7 @@
         },
         "hints": {
           "mirrorMode": "启用后，模型将水平镜像翻转。",
+          "autoMirror": "启用后，根据窗口在屏幕左/右半侧的位置自动翻转镜像。",
           "mouseMirror": "启用后，鼠标将镜像跟随手部移动。",
           "ignoreMouse": "启用后，模型将不再响应鼠标事件，适用于键盘模式或手柄模式。",
           "motionSound": "启用后，模型执行动作时会播放对应音效（如果存在）。",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -13,6 +13,7 @@
         "labels": {
           "modelSettings": "模型設定",
           "mirrorMode": "鏡像模式",
+          "autoMirror": "自動鏡像",
           "mouseMirror": "滑鼠游標鏡像",
           "ignoreMouse": "忽略滑鼠事件",
           "windowSettings": "視窗設定",
@@ -30,6 +31,7 @@
         },
         "hints": {
           "mirrorMode": "啟用後，模型將水平鏡像翻轉。",
+          "autoMirror": "啟用後，根據視窗在螢幕左/右半側的位置自動翻轉鏡像。",
           "mouseMirror": "啟用後，滑鼠游標將鏡像跟隨手部移動。",
           "ignoreMouse": "啟用後，模型將不再回應滑鼠事件，適用於鍵盤模式或手柄模式。",
           "motionSound": "啟用後，模型執行動作時會播放對應音效（如果存在）。",

--- a/src/pages/main/index.vue
+++ b/src/pages/main/index.vue
@@ -13,6 +13,7 @@ import { nth } from 'es-toolkit/compat'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { useAppMenu } from '@/composables/useAppMenu'
+import { useAutoMirror } from '@/composables/useAutoMirror'
 import { useDevice } from '@/composables/useDevice'
 import { useGamepad } from '@/composables/useGamepad'
 import { useModel } from '@/composables/useModel'
@@ -29,6 +30,7 @@ import { isWindows } from '@/utils/platform'
 import { clearObject } from '@/utils/shared'
 
 const { startListening } = useDevice()
+useAutoMirror()
 const appWindow = getCurrentWebviewWindow()
 const { modelSize, handleLoad, handleDestroy, handleResize, handleKeyChange } = useModel()
 const catStore = useCatStore()

--- a/src/pages/preference/components/cat/index.vue
+++ b/src/pages/preference/components/cat/index.vue
@@ -19,6 +19,13 @@ const catStore = useCatStore()
     </ProListItem>
 
     <ProListItem
+      :description="$t('pages.preference.cat.hints.autoMirror')"
+      :title="$t('pages.preference.cat.labels.autoMirror')"
+    >
+      <Switch v-model:checked="catStore.model.autoMirror" />
+    </ProListItem>
+
+    <ProListItem
       :description="$t('pages.preference.cat.hints.mouseMirror')"
       :title="$t('pages.preference.cat.labels.mouseMirror')"
     >

--- a/src/stores/cat.ts
+++ b/src/stores/cat.ts
@@ -5,6 +5,7 @@ export interface CatStore {
   model: {
     mirror: boolean
     mouseMirror: boolean
+    autoMirror: boolean
     motionSound: boolean
     behavior: boolean
     autoReleaseDelay: number
@@ -51,6 +52,7 @@ export const useCatStore = defineStore('cat', () => {
   const model = reactive<CatStore['model']>({
     mirror: false,
     mouseMirror: false,
+    autoMirror: false,
     motionSound: true,
     behavior: true,
     autoReleaseDelay: 3,


### PR DESCRIPTION
当开启「自动镜像」开关后，拖动猫窗口到屏幕左半侧时自动水平镜像翻转，
拖到右半侧时恢复，猫始终朝向屏幕中心。

- 新增 useAutoMirror composable，监听窗口移动事件并根据显示器 位置自动设置 mirror 状态
- cat store 新增 autoMirror 配置项，持久化到本地
- 偏好设置「猫咪设置」页新增「自动镜像」开关
- 更新 5 个语言文件的 i18n 文案