### PR TITLE
fix: 修复拖放事件中位置计算的逻辑

### DIFF
--- a/src/composables/useWindowState.ts
+++ b/src/composables/useWindowState.ts
@@ -29,7 +29,7 @@ export function useWindowState() {
     appWindow.onResized(onChange)
 
     appWindow.onScaleChanged(clampToMonitor)
-    appWindow.onScaleChanged(onSacleChanged)
+    appWindow.onScaleChanged(onScaleChanged)
   })
 
   const clampToMonitor = useDebounceFn(async () => {
@@ -56,7 +56,7 @@ export function useWindowState() {
     return appWindow.setPosition(new PhysicalPosition(clampedX, clampedY))
   }, 500)
 
-  const onSacleChanged = (event: Event<ScaleFactorChanged>) => {
+  const onScaleChanged = (event: Event<ScaleFactorChanged>) => {
     appStore.windowState[label] ??= {}
     appStore.windowState[label].scaleFactor = event.payload.scaleFactor
   }

--- a/src/composables/useWindowState.ts
+++ b/src/composables/useWindowState.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@tauri-apps/api/event'
+import type { ScaleFactorChanged } from '@tauri-apps/api/window'
 
 import { PhysicalPosition, PhysicalSize } from '@tauri-apps/api/dpi'
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow'
@@ -12,7 +13,7 @@ import { useAppStore } from '@/stores/app'
 import { useCatStore } from '@/stores/cat'
 import { getCursorMonitor } from '@/utils/monitor'
 
-export type WindowState = Record<string, Partial<PhysicalPosition & PhysicalSize> | undefined>
+export type WindowState = Record<string, Partial<PhysicalPosition & PhysicalSize & Pick<ScaleFactorChanged, 'scaleFactor'>> | undefined>
 
 const appWindow = getCurrentWebviewWindow()
 const { label } = appWindow
@@ -28,6 +29,7 @@ export function useWindowState() {
     appWindow.onResized(onChange)
 
     appWindow.onScaleChanged(clampToMonitor)
+    appWindow.onScaleChanged(onSacleChanged)
   })
 
   const clampToMonitor = useDebounceFn(async () => {
@@ -53,6 +55,11 @@ export function useWindowState() {
 
     return appWindow.setPosition(new PhysicalPosition(clampedX, clampedY))
   }, 500)
+
+  const onSacleChanged = (event: Event<ScaleFactorChanged>) => {
+    appStore.windowState[label] ??= {}
+    appStore.windowState[label].scaleFactor = event.payload.scaleFactor
+  }
 
   watch(() => catStore.window.keepInScreen, clampToMonitor)
 

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -28,7 +28,7 @@ onMounted(() => {
     const { type } = payload
 
     if (type === 'over') {
-      const { x, y } = payload.position
+      const { x, y } = payload.position.toLogical(devicePixelRatio)
 
       if (dropRef.value) {
         const { left, right, top, bottom } = dropRef.value.getBoundingClientRect()

--- a/src/pages/preference/components/model/components/upload/index.vue
+++ b/src/pages/preference/components/model/components/upload/index.vue
@@ -6,12 +6,13 @@ import { open } from '@tauri-apps/plugin-dialog'
 import { readDir } from '@tauri-apps/plugin-fs'
 import { message } from 'antdv-next'
 import { nanoid } from 'nanoid'
-import { onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { ModelMode } from '@/stores/model'
 
 import { INVOKE_KEY } from '@/constants'
+import { useAppStore } from '@/stores/app'
 import { useModelStore } from '@/stores/model'
 import { join } from '@/utils/path'
 
@@ -19,16 +20,17 @@ const dropRef = useTemplateRef('drop')
 const dragenter = ref(false)
 const selectPaths = ref<string[]>([])
 const modelStore = useModelStore()
+const appStore = useAppStore()
 const { t } = useI18n()
+const appWindow = getCurrentWebviewWindow()
+const scaleFactor = computed(() => appStore.windowState[appWindow.label]?.scaleFactor ?? devicePixelRatio)
 
 onMounted(() => {
-  const appWindow = getCurrentWebviewWindow()
-
   appWindow.onDragDropEvent(({ payload }) => {
     const { type } = payload
 
     if (type === 'over') {
-      const { x, y } = payload.position.toLogical(devicePixelRatio)
+      const { x, y } = payload.position.toLogical(scaleFactor.value)
 
       if (dropRef.value) {
         const { left, right, top, bottom } = dropRef.value.getBoundingClientRect()


### PR DESCRIPTION
`payload.position` 是物理像素，需要将其转为逻辑像素后再参与后续计算。